### PR TITLE
pom.xmlの余分な記述を削除

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,6 @@
 		</developer>
 	</developers>
 
-	<repositories>
-	</repositories>
-
-	<pluginRepositories>
-	</pluginRepositories>
-
 	<profiles>
 		<profile>
 			<id>deploy</id>
@@ -249,7 +243,6 @@
 					<autoReleaseAfterClose>true</autoReleaseAfterClose>
 				</configuration>
 			</plugin>
-
 		</plugins>
 	</build>
 
@@ -275,7 +268,6 @@
 					<docencoding>UTF-8</docencoding>
 					<locale>ja_JP</locale>
 					<javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-					<aggregate>true</aggregate>
 					<sourcepath>
 						sqlmapper-parent/sqlmapper-core/target/generated-sources/delombok
 						;sqlmapper-parent/sqlmapper-metamodel/target/generated-sources/delombok

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -14,15 +14,6 @@
 	<packaging>pom</packaging>
 	<description><![CDATA[ 各モジュールのテストのカバレージ「JaCoCo」のレポートを集約するためのプロジェクトです。 ]]></description>
 
-	<properties>
-	</properties>
-
-	<repositories>
-	</repositories>
-
-	<pluginRepositories>
-	</pluginRepositories>
-
 	<build>
 		<pluginManagement>
 		</pluginManagement>
@@ -39,20 +30,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<argLine>${jacocoArgs}</argLine>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>1.3.2</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>

--- a/sqlmapper-parent/pom.xml
+++ b/sqlmapper-parent/pom.xml
@@ -27,12 +27,6 @@
 		<module>sqlmapper-spring-boot</module>
 	</modules>
 
-	<repositories>
-	</repositories>
-
-	<pluginRepositories>
-	</pluginRepositories>
-
 	<build>
 		<resources>
 			<resource>
@@ -275,15 +269,7 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-site-plugin</artifactId>
-				<configuration>
-					<skip>${maven-site-plugin.skip}</skip>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.2.0</version>
 				<configuration>
 					<source>${java.version}</source>
 					<encoding>${project.build.sourceEncoding}</encoding>
@@ -298,7 +284,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jxr-plugin</artifactId>
-				<version>3.0.0</version>
 				<configuration>
 					<aggregate>true</aggregate>
 					<inputEncoding>UTF-8</inputEncoding>

--- a/sqlmapper-parent/sqlmapper-core/pom.xml
+++ b/sqlmapper-parent/sqlmapper-core/pom.xml
@@ -19,41 +19,6 @@
 		<jacoco.include.package>com.github.mygreen.sqlmapper.core.*</jacoco.include.package>
 	</properties>
 
-	<build>
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-			</resource>
-			<resource>
-				<directory>src/main/java</directory>
-				<includes>
-					<include>**</include>
-				</includes>
-				<excludes>
-					<exclude>**/*.java</exclude>
-				</excludes>
-			</resource>
-		</resources>
-		<testResources>
-			<testResource>
-				<directory>src/test/resources</directory>
-			</testResource>
-			<testResource>
-				<directory>src/test/java</directory>
-				<includes>
-					<include>**</include>
-				</includes>
-				<excludes>
-					<exclude>**/*.java</exclude>
-				</excludes>
-			</testResource>
-		</testResources>
-		<pluginManagement>
-		</pluginManagement>
-		<plugins>
-		</plugins>
-	</build>
-
 	<dependencies>
 
 		<!-- Utility -->

--- a/sqlmapper-parent/sqlmapper-metamodel/pom.xml
+++ b/sqlmapper-parent/sqlmapper-metamodel/pom.xml
@@ -18,12 +18,4 @@
 		<jacoco.include.package>com.github.mygreen.sqlmapper.metamodel.*</jacoco.include.package>
 	</properties>
 
-	<build>
-		<plugins>
-		</plugins>
-	</build>
-
-	<dependencies>
-	</dependencies>
-
 </project>

--- a/sqlmapper-parent/sqlmapper-spring-boot/pom.xml
+++ b/sqlmapper-parent/sqlmapper-spring-boot/pom.xml
@@ -35,7 +35,4 @@
 		</dependencies>
 	</dependencyManagement>
 
-	<dependencies>
-	</dependencies>
-
 </project>

--- a/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-autoconfigure/pom.xml
+++ b/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-autoconfigure/pom.xml
@@ -18,9 +18,6 @@
 		<jacoco.include.package>com.github.mygreen.sqlmapper.boot.autoconfigure.*</jacoco.include.package>
 	</properties>
 
-	<build>
-	</build>
-
 	<dependencies>
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>

--- a/sqlmapper-sample/sqlmapper-sample-spring-boot/pom.xml
+++ b/sqlmapper-sample/sqlmapper-sample-spring-boot/pom.xml
@@ -215,6 +215,4 @@
 
 	</dependencies>
 
-
-
 </project>


### PR DESCRIPTION
pom.xmlの記述の整理

- 空タグを削除。
- report-aggregateにてJaCoCo以外の余分なレポート出力設定を削除
- プラグインのバージョン指定をrootプロジェクトに集約