### PR TITLE
識別子の生成戦略を指定したとき、DBの方言ごとにサポートしているかチェックを追加

### DIFF
--- a/docs/release/v0_3.adoc
+++ b/docs/release/v0_3.adoc
@@ -6,4 +6,8 @@
 
 * https://github.com/mygreen/sqlmapper/pull/4[#4, window="_blank"] - <<custom_id_gnerarator,識別子の独自実装を指定できる機能>>を追加。
 
+* https://github.com/mygreen/sqlmapper/pull/5[#5, window="_blank"] - 以下のメソッド名を変更。
+** ``Dialect#isSupportedGenerationType`` -> ``Dialect#supportsGenerationType``
+** ``Dialect#isSupportedSelectForUpdate`` -> ``Dialect#supportsSelectForUpdate``
 
+* https://github.com/mygreen/sqlmapper/pull/6[#6, window="_blank"] - 識別子の生成戦略を ``@GeneratedValue(strategy=...)`` で指定したとき、DBの方言ごとにサポートしているかチェックを追加しました。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/messages.properties
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/messages.properties
@@ -21,6 +21,7 @@ property.anno.attr.notSupportValue='{classType}#{property}'において、アノ
 property.anno.attr.wrongFormat='{classType}#{property}'において、アノテーション'{anno}'の属性'{attrName}'の値'{attrValue}'は不正なフォーマットです。
 property.anno.attr.noSuchBeanDefinition='{classType}#{property}'において、アノテーション'{anno}'の属性'{attrName}'の値'{attrValue}'は、Springのコンテナには登録されていません。
 property.anno.attr.beanNotOfRequiredType='{classType}#{property}'において、アノテーション'{anno}'の属性'{attrName}'の値'{attrValue}'で指定したSpringBeanは、'{requiredType}' を実装する必要があります。
+property.anno.attr.notSupportForDialect='{classType}#{property}'において、アノテーション'{anno}'の属性'{attrName}'の値'{attrValue}'は、DBMS '{dialectName}'のときはサポートしていません。
 
 typeValue.conversionFail='{value}' を '{classType}' に変換失敗しました。
 typeValue.notFound='{entityClass}#{property}' ({propertyType}) に対するValueTypeが見つかりませんでした。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
@@ -276,6 +276,18 @@ public class PropertyMetaFactory {
         final Class<?> propertyType = propertyMeta.getPropertyType();
 
         GenerationType generationType = annoGeneratedValue.get().strategy();
+        if(generationType != GenerationType.AUTO && !dialect.supportsGenerationType(generationType)) {
+            throw new InvalidEntityException(entityMeta.getEntityType(), messageFormatter.create("property.anno.attr.notSupportForDialect")
+                    .paramWithClass("classType", entityMeta.getEntityType())
+                    .param("property", propertyMeta.getName())
+                    .paramWithAnno("anno", GeneratedValue.class)
+                    .param("attrName", "strategy")
+                    .param("attrValue", generationType)
+                    .param("dialectName", dialect.getName())
+                    .format());
+        }
+
+        // 生成戦略の補完
         if(generationType == GenerationType.AUTO) {
             generationType = dialect.getDefaultGenerationType();
         }


### PR DESCRIPTION
エンティティにて、アノテーション ``GenerationType(strategry=XXXX)`` にて、生成戦略を指定したとき、DBの方言ごとにサポートしているかどうかのチェックを追加。

```java
@Entity
public class User {
    
    @Id
    @GeneratedValue(strategry=GenerationType.IDENTITY)
    private long id;

    private String name;
    // setter/getterメソッドは省略
}
```