### PR TITLE
フィールドに transient修飾子が付与されていても永続化対象外とならない事象を修正

### DIFF
--- a/docs/release/v0_3.adoc
+++ b/docs/release/v0_3.adoc
@@ -1,13 +1,15 @@
 = ver.0.3 - 2021-xx-xx
 
-* https://github.com/mygreen/sqlmapper/pull/3[#3, window="_blank"] - 監査情報を記録するためのアノテーションの名称を変更。
+* https://github.com/mygreen/sqlmapper/pull/3[#3, window="_blank"] - 監査情報を記録するためのアノテーションの名称を変更しました。
 ** ``@ModfiedAt`` -> ``UpdatedAt``
 ** ``@ModfiedBy`` -> ``UpdatedBy``
 
 * https://github.com/mygreen/sqlmapper/pull/4[#4, window="_blank"] - <<custom_id_gnerarator,識別子の独自実装を指定できる機能>>を追加。
 
-* https://github.com/mygreen/sqlmapper/pull/5[#5, window="_blank"] - 以下のメソッド名を変更。
+* https://github.com/mygreen/sqlmapper/pull/5[#5, window="_blank"] - 以下のメソッド名を変更しました。
 ** ``Dialect#isSupportedGenerationType`` -> ``Dialect#supportsGenerationType``
 ** ``Dialect#isSupportedSelectForUpdate`` -> ``Dialect#supportsSelectForUpdate``
 
 * https://github.com/mygreen/sqlmapper/pull/6[#6, window="_blank"] - 識別子の生成戦略を ``@GeneratedValue(strategy=...)`` で指定したとき、DBの方言ごとにサポートしているかチェックを追加しました。
+
+* https://github.com/mygreen/sqlmapper/pull/7[#7, window="_blank"] - フィールドに 修飾子 `transient` が付与されていても永続化対象外とならない事象を修正しました。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMeta.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMeta.java
@@ -362,10 +362,13 @@ public class PropertyMeta {
 
     /**
      * 永続化対象外かどうか判定する。
+     * <p>永続化対象外とは、アノテーション {@link Transient}が付与されているか、
+     * または、フィールドに修飾子 {@code transient} が付与されているかどうかで判定します。
      * @return 永続化対象外のとき {@literal true} を返す。
      */
     public boolean isTransient() {
-        return hasAnnotation(Transient.class);
+        return hasAnnotation(Transient.class)
+                || field.map(f -> Modifier.isTransient(f.getModifiers())).orElse(false);
     }
 
     /**


### PR DESCRIPTION
フィールドに transient修飾子が付与されてる場合、永続化対象外となるよう修正。

```java
@Entity
public class Sample {
    // アノテーション @Transientを付与しなくても永続化対象外とする
    private transient String aaaa;
}
```