### PR TITLE
OracleのときのエンティティのプロパティがBoolean型のときをサポート/LIMIT句の間違いを修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/OracleLegacyDialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/OracleLegacyDialect.java
@@ -1,14 +1,40 @@
 package com.github.mygreen.sqlmapper.core.dialect;
 
+import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+
 /**
  * 古いOracleDBの方言です。
  * <p>Oracle11以前が対象です。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
 public class OracleLegacyDialect extends OracleDialect {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return <ul>
+     *  <li>{@link GenerationType#IDENTITY} : {@literal false}</li>
+     *  <li>{@link GenerationType#SEQUENCE} : {@literal true}</li>
+     *  <li>{@link GenerationType#TABLE} : {@literal true}</li>
+     *  <li>その他 : {@literal false}</li>
+     * </ul>
+     */
+    @Override
+    public boolean supportsGenerationType(GenerationType generationType) {
+        switch(generationType) {
+            case IDENTITY:
+                return false;
+            case SEQUENCE:
+                return true;
+            case TABLE:
+                return true;
+            default:
+                return false;
+        }
+    }
 
     /**
      * {@inheritDoc}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/OracleLegacyDialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/OracleLegacyDialect.java
@@ -1,12 +1,5 @@
 package com.github.mygreen.sqlmapper.core.dialect;
 
-import org.springframework.lang.Nullable;
-
-import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
-import com.github.mygreen.sqlmapper.core.type.ValueType;
-import com.github.mygreen.sqlmapper.core.type.standard.BooleanType;
-import com.github.mygreen.sqlmapper.core.type.standard.NumberableBooleanType;
-
 /**
  * 古いOracleDBの方言です。
  * <p>Oracle11以前が対象です。
@@ -16,55 +9,6 @@ import com.github.mygreen.sqlmapper.core.type.standard.NumberableBooleanType;
  *
  */
 public class OracleLegacyDialect extends OracleDialect {
-
-    private final NumberableBooleanType objectiveBooleanType = new NumberableBooleanType(false);
-
-    private final NumberableBooleanType primitiveBooleanType = new NumberableBooleanType(true);
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return <ul>
-     *  <li>{@link GenerationType#IDENTITY} : {@literal false}</li>
-     *  <li>{@link GenerationType#SEQUENCE} : {@literal true}</li>
-     *  <li>{@link GenerationType#TABLE} : {@literal true}</li>
-     *  <li>その他 : {@literal false}</li>
-     * </ul>
-     */
-    @Override
-    public boolean supportsGenerationType(GenerationType generationType) {
-        switch(generationType) {
-            case IDENTITY:
-                return false;
-            case SEQUENCE:
-                return true;
-            case TABLE:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return 与えられた値が {@literal boolean/Boolean}のとき、整数型に変換する {@link NumberableBooleanType} に変換します。
-     */
-    @Override
-    public ValueType<?> getValueType(@Nullable ValueType<?> valueType) {
-        if(valueType == null) {
-            return null;
-        }
-
-        if(valueType instanceof BooleanType) {
-            if(((BooleanType)valueType).isForPrimitive()) {
-                return primitiveBooleanType;
-            } else {
-                return objectiveBooleanType;
-            }
-        }
-        return valueType;
-    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Oracleのとき、DB側のカラムが整数で、Java側のエンティティのプロパティがboolean/Boolean型のときをサポート。
- Oracle12c以降は、boolean型をサポートしていると勘違いして、OralceLegacyDialect にのみ実装していた。
  - OralceLegacyDialect を修正して、``getValueType`` の実装を ``OracleLegacyDialect`` に移動。
- ``OracleDialect`` のLIMIT句の文法間違いを修正。
