### PR TITLE
JdbcTemplateの設定をクエリ単位に設定可能に修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/SqlMapperContext.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/SqlMapperContext.java
@@ -1,11 +1,16 @@
 package com.github.mygreen.sqlmapper.core;
 
+import javax.sql.DataSource;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import com.github.mygreen.messageformatter.MessageFormatter;
 import com.github.mygreen.splate.SqlTemplateEngine;
+import com.github.mygreen.sqlmapper.core.config.JdbcTemplateProperties;
 import com.github.mygreen.sqlmapper.core.dialect.Dialect;
 import com.github.mygreen.sqlmapper.core.meta.EntityMetaFactory;
 import com.github.mygreen.sqlmapper.core.meta.StoredParamMetaFactory;
@@ -22,56 +27,77 @@ import lombok.Setter;
  * @author T.TSUCHIE
  *
  */
+@Getter
+@Setter
 public class SqlMapperContext {
 
-    @Getter
-    @Setter
-    private JdbcTemplate jdbcTemplate;
-
-    @Getter
-    @Setter
+    /**
+     * テーブル、カラムなどの命名規則。
+     */
     private NamingRule namingRule;
 
-    @Getter
-    @Setter
+    /**
+     * エラーメッセージなどのフォーマッター。
+     */
     private MessageFormatter messageFormatter;
 
-    @Getter
-    @Setter
+    /**
+     * RDMSごとの方言。
+     */
     private Dialect dialect;
 
-    @Getter
-    @Setter
+    /**
+     * エンティティのメタ情報の作成処理。
+     */
     private EntityMetaFactory entityMetaFactory;
 
-    @Getter
-    @Setter
+    /**
+     * ストアドプロシージャ／ファンクションのパラメータのメタ情報の作成処理。
+     */
     private StoredParamMetaFactory storedParamMetaFactory;
 
     /**
-     * 主キーの生成時用のトランザクションテンプレート。
-     *
+     * Java ⇔ SQL の相互変換処理を管理。
      */
-    @Getter
-    @Setter
-    private TransactionTemplate idGeneratorTransactionTemplate;
+    private ValueTypeRegistry valueTypeRegistry;
+
+    /**
+     * 接続先DBのデータソース。
+     */
+    private DataSource dataSource;
+
+    /**
+     * {@link JdbcTemplate} の初期値。
+     */
+    private JdbcTemplateProperties jdbcTemplateProperties;
+
+    /**
+     * トランザクションマネージャ。
+     * <p>主キー生成時のトランザクション設定に使用します。
+     */
+    private PlatformTransactionManager transactionManager;
 
     /**
      * 各SQL実行時のイベントを配信する機能
      */
-    @Getter
-    @Setter
     private ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * SQLテンプレートエンジン
      */
-    @Getter
-    @Setter
     private SqlTemplateEngine sqlTemplateEngine;
 
-    @Getter
-    @Setter
-    private ValueTypeRegistry valueTypeRegistry;
+    /**
+     * トランザクションの伝搬タイプが {@link TransactionDefinition#PROPAGATION_REQUIRES_NEW} のトランザクションテンプレートを作成します。
+     * <p>ID生成用のトランザクションテンプレートとして使用します。
+     *
+     * @since 0.3
+     * @return トランザクションテンプレート。
+     */
+    public TransactionTemplate txRequiresNew() {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return transactionTemplate;
+    }
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/config/JdbcTemplateProperties.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/config/JdbcTemplateProperties.java
@@ -1,0 +1,46 @@
+package com.github.mygreen.sqlmapper.core.config;
+
+import org.springframework.jdbc.SQLWarningException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import lombok.Data;
+
+/**
+ * {@link JdbcTemplate}による設定。
+ * <p>各クエリ実行時に上書きすることもできます。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+@Data
+public class JdbcTemplateProperties {
+
+    /**
+     * フェッチサイズを設定します。
+     * <p>これをデフォルト値よりも高く設定すると、大きな結果セットを処理する際に、メモリ消費を犠牲にして処理速度が向上します。
+     * <p>デフォルトは -1 で、JDBC ドライバーのデフォルト設定を使用することを示します（つまり、特定のフェッチサイズ設定をドライバーに渡さないようにします）。
+     */
+    private int fetchSize;
+
+    /**
+     * 最大行数を設定します。
+     * <p>JDBCのStatementレベルで、結果セットのオブジェクトが含むことのできる最大行数を制限します。制限値を超えた場合は通知なしの除外されます。
+     * <p>デフォルトは -1 で、JDBC ドライバーのデフォルト構成を使用することを示します（つまり、特定の最大行設定をドライバーに渡さないようにします）。
+     */
+    private int maxRows;
+
+    /**
+     * クエリ実行時ののクエリタイムアウトを設定します。
+     * <p>デフォルトは -1 で、JDBC ドライバーのデフォルトを使用する（つまり、ドライバーで特定のクエリタイムアウト設定を渡さない）ことを示します。
+     */
+    private int queryTimeout;
+
+    /**
+     * SQLの警告を無視するかどうかを設定します。
+     * <p>デフォルトは "true" で、すべての警告を飲み込んで記録します。
+     * <p>このフラグを "false" に切り替えて、代わりに JdbcTemplate が {@link SQLWarningException} をスローするようにします。
+     *
+     */
+    private boolean ignoreWarning;
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
@@ -28,6 +28,7 @@ import com.github.mygreen.sqlmapper.core.annotation.SequenceGenerator;
 import com.github.mygreen.sqlmapper.core.annotation.TableGenerator;
 import com.github.mygreen.sqlmapper.core.annotation.Temporal;
 import com.github.mygreen.sqlmapper.core.annotation.Version;
+import com.github.mygreen.sqlmapper.core.config.JdbcTemplateProperties;
 import com.github.mygreen.sqlmapper.core.config.TableIdGeneratorProperties;
 import com.github.mygreen.sqlmapper.core.dialect.Dialect;
 import com.github.mygreen.sqlmapper.core.id.IdGenerationContext;
@@ -39,6 +40,7 @@ import com.github.mygreen.sqlmapper.core.id.TableIdGenerator;
 import com.github.mygreen.sqlmapper.core.id.TableIdIncrementer;
 import com.github.mygreen.sqlmapper.core.id.UUIDGenerator;
 import com.github.mygreen.sqlmapper.core.naming.NamingRule;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
 import com.github.mygreen.sqlmapper.core.type.ValueTypeRegistry;
 import com.github.mygreen.sqlmapper.core.util.ClassUtils;
@@ -84,7 +86,7 @@ public class PropertyMetaFactory {
     @Getter
     @Setter
     @Autowired
-    private JdbcTemplate jdbcTemplate;
+    private JdbcTemplateProperties jdbcTemplateProperties;
 
     @Getter
     @Setter
@@ -418,7 +420,7 @@ public class PropertyMetaFactory {
             }
 
             TableIdGenerator tableIdGenerator = new TableIdGenerator(
-                    new TableIdIncrementer(jdbcTemplate, tableIdContext),
+                    new TableIdIncrementer(getJdbcTemplate(), tableIdContext),
                     propertyMeta.getPropertyType(), sequenceName);
 
 
@@ -552,6 +554,15 @@ public class PropertyMetaFactory {
                     .format());
         }
 
+    }
+
+    /**
+     * {@link TableIdGenerator}用の {@link JdbcTemplate} を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(dataSource, jdbcTemplateProperties)
+                .build();
     }
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/JdbcTemplateBuilder.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/JdbcTemplateBuilder.java
@@ -1,0 +1,100 @@
+package com.github.mygreen.sqlmapper.core.query;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.github.mygreen.sqlmapper.core.config.JdbcTemplateProperties;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * {@link JdbcTemplate}を組み立てます。
+ *
+ *
+ * @author T.TSUCHIE
+ *
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class JdbcTemplateBuilder {
+
+    /**
+     * データソース
+     */
+    private final DataSource dataSource;
+
+    /**
+     * 初期値のプロパティ
+     */
+    private final JdbcTemplateProperties init;
+
+    /**
+     * フェッチサイズ
+     */
+    @Accessors(chain = true, fluent = true)
+    @Setter
+    private Integer fetchSize;
+
+    /**
+     * 最大取得行数
+     */
+    @Accessors(chain = true, fluent = true)
+    @Setter
+    private Integer maxRows;
+
+    /**
+     * クエリのタイムアウト
+     */
+    @Accessors(chain = true, fluent = true)
+    @Setter
+    private Integer queryTimeout;
+
+    /**
+     * {@link JdbcTemplate}を組み立てるためのビルダのインスタンスを作成します。
+     * @param dataSource データソース
+     * @param init 初期値設定値。
+     * @return ビルダクラス。
+     */
+    public static JdbcTemplateBuilder create(DataSource dataSource, @NonNull JdbcTemplateProperties init) {
+        JdbcTemplateBuilder builder = new JdbcTemplateBuilder(dataSource, init);
+        return builder;
+    }
+
+    /**
+     * 設定値をもとに{@link JdbcTemplate}のインスタンスを組み立てます。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    public JdbcTemplate build() {
+
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.setResultsMapCaseInsensitive(true);
+        jdbcTemplate.setIgnoreWarnings(init.isIgnoreWarning());
+
+        if(fetchSize != null) {
+            jdbcTemplate.setFetchSize(fetchSize);
+        } else {
+            jdbcTemplate.setFetchSize(init.getFetchSize());
+        }
+
+        if(maxRows != null) {
+            jdbcTemplate.setMaxRows(maxRows);
+        } else {
+            jdbcTemplate.setMaxRows(init.getMaxRows());
+        }
+
+        if(queryTimeout != null) {
+            jdbcTemplate.setQueryTimeout(queryTimeout);
+        } else {
+            jdbcTemplate.setQueryTimeout(init.getQueryTimeout());
+        }
+
+        return jdbcTemplate;
+
+    }
+
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoAnyDelete.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoAnyDelete.java
@@ -5,11 +5,22 @@ import com.github.mygreen.sqlmapper.metamodel.Predicate;
 /**
  * 任意の条件を指定して削除を行うSQLを自動生成するクエリです。
  *
+ * @version 0.3
  * @author T.TSUCHIE
  * @param <T> 処理対象となるエンティティの型
  *
  */
 public interface AutoAnyDelete<T> {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoAnyDelete<T> queryTimeout(int seconds);
 
     /**
      * 検索条件を指定します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoAnyDeleteExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoAnyDeleteExecutor.java
@@ -4,7 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.jdbc.core.JdbcTemplate;
+
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 import com.github.mygreen.sqlmapper.core.query.TableNameResolver;
 import com.github.mygreen.sqlmapper.core.query.WhereClause;
 import com.github.mygreen.sqlmapper.core.where.metamodel.MetamodelWhere;
@@ -105,7 +108,17 @@ public class AutoAnyDeleteExecutor {
      */
     public int execute() {
         prepare();
-        return context.getJdbcTemplate().update(executedSql, paramValues.toArray());
+        return getJdbcTemplate().update(executedSql, paramValues.toArray());
+    }
+
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(query.getQueryTimeout())
+                .build();
     }
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoAnyDeleteImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoAnyDeleteImpl.java
@@ -32,6 +32,9 @@ public class AutoAnyDeleteImpl<T> implements AutoAnyDelete<T> {
     @Getter
     private final EntityMeta entityMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
     /**
      * クライテリアです。
      */
@@ -45,6 +48,13 @@ public class AutoAnyDeleteImpl<T> implements AutoAnyDelete<T> {
         this.entityMeta = context.getEntityMetaFactory().create(entityPath.getType());
         this.baseClass = (Class<T>)entityMeta.getEntityType();
     }
+
+    @Override
+    public AutoAnyDeleteImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
+    }
+
 
     @Override
     public AutoAnyDeleteImpl<T> where(@NonNull Predicate where) {

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDelete.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDelete.java
@@ -5,12 +5,22 @@ import org.springframework.dao.OptimisticLockingFailureException;
 /**
  * バッチ削除を行うSQLを自動生成するクエリです。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  * @param <T> 処理対象となるエンティティの型
  */
 public interface AutoBatchDelete<T> {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoBatchDelete<T> queryTimeout(int seconds);
 
     /**
      * バージョンプロパティを無視して削除します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDeleteExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDeleteExecutor.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
 import com.github.mygreen.sqlmapper.core.meta.PropertyMeta;
 import com.github.mygreen.sqlmapper.core.meta.PropertyValueInvoker;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 import com.github.mygreen.sqlmapper.core.query.WhereClause;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
 import com.github.mygreen.sqlmapper.core.where.simple.SimpleWhereBuilder;
@@ -142,13 +144,23 @@ public class AutoBatchDeleteExecutor {
 
         prepare();
 
-        final int rows = context.getJdbcTemplate().update(executedSql, paramValues.toArray());
+        final int rows = getJdbcTemplate().update(executedSql, paramValues.toArray());
         if(isOptimisticLock()) {
             validateRows(rows);
         }
         return rows;
 
 
+    }
+
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(query.getQueryTimeout())
+                .build();
     }
 
     /**
@@ -161,4 +173,5 @@ public class AutoBatchDeleteExecutor {
                     .format());
         }
     }
+
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDeleteImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDeleteImpl.java
@@ -38,6 +38,9 @@ public class AutoBatchDeleteImpl<T> implements AutoBatchDelete<T> {
     @Getter
     private final EntityMeta entityMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
     /**
      * バージョンプロパティを無視して削除するかどうか。
      */
@@ -93,6 +96,12 @@ public class AutoBatchDeleteImpl<T> implements AutoBatchDelete<T> {
      */
     public int getEntitySize() {
         return entities.length;
+    }
+
+    @Override
+    public AutoBatchDeleteImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchInsert.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchInsert.java
@@ -16,6 +16,15 @@ import com.github.mygreen.sqlmapper.metamodel.PropertyPath;
 public interface AutoBatchInsert<T> {
 
     /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoBatchInsert<T> queryTimeout(int seconds);
+
+    /**
      * 指定のプロパティのみを挿入対象とします。
      * <p>アノテーション {@literal @Column(insertable = false)} が設定されているプロパティは対象外となります。</p>
      *

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchInsertImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchInsertImpl.java
@@ -38,6 +38,9 @@ public class AutoBatchInsertImpl<T> implements AutoBatchInsert<T> {
     @Getter
     private final EntityMeta entityMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
     /**
      * 挿入対象とするプロパティ一覧
      */
@@ -82,6 +85,12 @@ public class AutoBatchInsertImpl<T> implements AutoBatchInsert<T> {
      */
     public int getEntitySize() {
         return entities.length;
+    }
+
+    @Override
+    public AutoBatchInsertImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchUpdate.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchUpdate.java
@@ -8,12 +8,22 @@ import com.github.mygreen.sqlmapper.metamodel.PropertyPath;
 /**
  * バッチ更新を行うSQLを自動生成するクエリです。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
- * @param <T>
+ * @param <T> 処理対象となるエンティティの型
  */
 public interface AutoBatchUpdate<T> {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoBatchUpdate<T> queryTimeout(int seconds);
 
     /**
      * バージョンプロパティを通常の更新対象に含め、バージョンチェックの対象外とします。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchUpdateExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchUpdateExecutor.java
@@ -3,10 +3,12 @@ package com.github.mygreen.sqlmapper.core.query.auto;
 import java.util.List;
 
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
 import com.github.mygreen.sqlmapper.core.meta.PropertyMeta;
 import com.github.mygreen.sqlmapper.core.meta.PropertyValueInvoker;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 import com.github.mygreen.sqlmapper.core.query.SetClause;
 import com.github.mygreen.sqlmapper.core.query.WhereClause;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
@@ -204,7 +206,7 @@ public class AutoBatchUpdateExecutor {
             return new int[query.getEntitySize()];
         }
 
-        int[] res = context.getJdbcTemplate().batchUpdate(executedSql, QueryUtils.convertBatchArgs(batchParams));
+        int[] res = getJdbcTemplate().batchUpdate(executedSql, QueryUtils.convertBatchArgs(batchParams));
 
         final int dataSize = query.getEntitySize();
         for(int i=0; i < dataSize; i++) {
@@ -221,6 +223,16 @@ public class AutoBatchUpdateExecutor {
 
         return res;
 
+    }
+
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(query.getQueryTimeout())
+                .build();
     }
 
     /**

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchUpdateImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchUpdateImpl.java
@@ -39,6 +39,9 @@ public class AutoBatchUpdateImpl<T> implements AutoBatchUpdate<T> {
     @Getter
     private final EntityMeta entityMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
     /**
      * バージョンプロパティを更新対象に含めるかどうか。
      */
@@ -106,6 +109,12 @@ public class AutoBatchUpdateImpl<T> implements AutoBatchUpdate<T> {
      */
     public int getEntitySize() {
         return entities.length;
+    }
+
+    @Override
+    public AutoBatchUpdateImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoDelete.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoDelete.java
@@ -5,11 +5,22 @@ import org.springframework.dao.OptimisticLockingFailureException;
 /**
  * 削除を行うSQLを自動生成するクエリです。
  *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  * @param <T> 処理対象となるエンティティの型
  */
 public interface AutoDelete<T> {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoDelete<T> queryTimeout(int seconds);
 
     /**
      * バージョンプロパティを無視して削除します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoDeleteExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoDeleteExecutor.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
 import com.github.mygreen.sqlmapper.core.meta.PropertyMeta;
 import com.github.mygreen.sqlmapper.core.meta.PropertyValueInvoker;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 import com.github.mygreen.sqlmapper.core.query.WhereClause;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
 import com.github.mygreen.sqlmapper.core.where.simple.SimpleWhereBuilder;
@@ -132,13 +134,22 @@ public class AutoDeleteExecutor {
 
         prepare();
 
-        final int rows = context.getJdbcTemplate().update(executedSql, paramValues.toArray());
+        final int rows = getJdbcTemplate().update(executedSql, paramValues.toArray());
         if(isOptimisticLock()) {
             validateRows(rows);
         }
         return rows;
 
+    }
 
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(query.getQueryTimeout())
+                .build();
     }
 
     /**

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoDeleteImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoDeleteImpl.java
@@ -38,6 +38,9 @@ public class AutoDeleteImpl<T> implements AutoDelete<T> {
     @Getter
     private final EntityMeta entityMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
     /**
      * バージョンプロパティを無視して削除するかどうか。
      */
@@ -66,6 +69,11 @@ public class AutoDeleteImpl<T> implements AutoDelete<T> {
                     .paramWithClass("entityType", entityMeta.getEntityType())
                     .format());
         }
+    }
+
+    public AutoDeleteImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoFunctionCall.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoFunctionCall.java
@@ -12,6 +12,16 @@ package com.github.mygreen.sqlmapper.core.query.auto;
 public interface AutoFunctionCall<T> {
 
     /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoFunctionCall<T> queryTimeout(int seconds);
+
+    /**
      * ストアドファンクションを呼び出します。
      * @return ファンクションの戻り値
      */

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsert.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsert.java
@@ -8,12 +8,22 @@ import com.github.mygreen.sqlmapper.metamodel.PropertyPath;
 /**
  * 挿入を行うSQLを自動生成するクエリです。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  * @param <T> 処理対象となるエンティティの型
  */
 public interface AutoInsert<T> {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoInsert<T> queryTimeout(int seconds);
 
     /**
      * 指定のプロパティのみを挿入対象とします。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsertImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsertImpl.java
@@ -42,6 +42,9 @@ public class AutoInsertImpl<T> implements AutoInsert<T> {
     @Getter
     private final EntityMeta entityMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
     /**
      * 挿入対象とするプロパティ一覧
      */
@@ -58,6 +61,12 @@ public class AutoInsertImpl<T> implements AutoInsert<T> {
         this.context = context;
         this.entity = entity;
         this.entityMeta = context.getEntityMetaFactory().create(entity.getClass());
+    }
+
+    @Override
+    public AutoInsertImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoProcedureCall.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoProcedureCall.java
@@ -11,6 +11,15 @@ package com.github.mygreen.sqlmapper.core.query.auto;
 public interface AutoProcedureCall {
 
     /**
+     * クエリタイムアウトの秒数を設定します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoProcedureCall queryTimeout(int seconds);
+
+    /**
      * ストアドプロシージャを呼び出します。
      */
     void execute();

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoProcedureCallImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoProcedureCallImpl.java
@@ -3,12 +3,14 @@ package com.github.mygreen.sqlmapper.core.query.auto;
 import java.util.Map;
 import java.util.Optional;
 
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.SqlParameter;
 import org.springframework.jdbc.core.simple.SimpleJdbcCall;
 
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
 import com.github.mygreen.sqlmapper.core.StoredName;
 import com.github.mygreen.sqlmapper.core.meta.StoredParamMeta;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 
 import lombok.Getter;
 
@@ -39,6 +41,9 @@ public class AutoProcedureCallImpl extends AutoStoredExecutorSupport implements 
      */
     private final StoredParamMeta paramMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
     /**
      * パラメータなしのコンストラクタ
      *
@@ -60,9 +65,15 @@ public class AutoProcedureCallImpl extends AutoStoredExecutorSupport implements 
     }
 
     @Override
+    public AutoProcedureCallImpl queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
+    }
+
+    @Override
     public void execute() {
 
-        final SimpleJdbcCall jdbcCall = new SimpleJdbcCall(context.getJdbcTemplate())
+        final SimpleJdbcCall jdbcCall = new SimpleJdbcCall(getJdbcTemplate())
                 .withProcedureName(procedureName.getName());
 
         if(procedureName.getCatalog() != null) {
@@ -91,5 +102,15 @@ public class AutoProcedureCallImpl extends AutoStoredExecutorSupport implements 
             }
         }
 
+    }
+
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(queryTimeout)
+                .build();
     }
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelect.java
@@ -17,11 +17,49 @@ import com.github.mygreen.sqlmapper.metamodel.PropertyPath;
 /**
  * 抽出を行うSQLを自動生成するクエリです。
  *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  * @param <T> 処理対象となるエンティティの型
  */
 public interface AutoSelect<T> {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoSelect<T> queryTimeout(int seconds);
+
+    /**
+     * フェッチ数を設定します。
+     * <p>これをデフォルト値よりも高く設定すると、大きな結果セットを処理する際に、メモリ消費を犠牲にして処理速度が向上します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param fetchSize フェッチ数
+     * @return 自身のインスタンス。
+     */
+    AutoSelect<T> fetchSize(int fetchSize);
+
+    /**
+     * 最大行数を設定します。
+     * <p>JDBCのStatementレベルで、結果セットのオブジェクトが含むことのできる最大行数を制限します。
+     *  <br>制限値を超えた場合は通知なしの除外されます。
+     * </p>
+     * <p>RDMSでLIMIT句がサポートされていない場合に使用します。
+     *  <br>LIMIT句がサポートされている場合は、{@link #limit(int)} を使用します。
+     * </p>
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param maxRows 最大行数
+     * @return 自身のインスタンス。
+     */
+    AutoSelect<T> maxRows(int maxRows);
 
     /**
      * ヒントを設定します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelectImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelectImpl.java
@@ -60,6 +60,15 @@ public class AutoSelectImpl<T> implements AutoSelect<T> {
     @Getter
     private final Map<Class<?>, EntityMeta> entityMetaMap = new HashMap<>();
 
+    @Getter
+    private Integer queryTimeout;
+
+    @Getter
+    private Integer fetchSize;
+
+    @Getter
+    private Integer maxRows;
+
     /**
      * SQLのヒントです。
      */
@@ -155,6 +164,24 @@ public class AutoSelectImpl<T> implements AutoSelect<T> {
         this.baseClass = (Class<T>)entityMeta.getEntityType();
 
         this.entityMetaMap.put(entityPath.getType(), context.getEntityMetaFactory().create(entityPath.getType()));
+    }
+
+    @Override
+    public AutoSelectImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
+    }
+
+    @Override
+    public AutoSelectImpl<T> fetchSize(int fetchSize) {
+        this.fetchSize = fetchSize;
+        return this;
+    }
+
+    @Override
+    public AutoSelectImpl<T> maxRows(int maxRows) {
+        this.maxRows = maxRows;
+        return this;
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoUpdate.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoUpdate.java
@@ -10,12 +10,22 @@ import com.github.mygreen.sqlmapper.metamodel.PropertyPath;
 /**
  * 更新を行うSQLを自動生成するクエリです。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  * @param <T> 処理対象となるエンティティの型
  */
 public interface AutoUpdate<T> {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    AutoUpdate<T> queryTimeout(int seconds);
 
     /**
      * バージョンプロパティを通常の更新対象に含め、バージョンチェックの対象外とします。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoUpdateExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoUpdateExecutor.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
 import com.github.mygreen.sqlmapper.core.meta.PropertyMeta;
 import com.github.mygreen.sqlmapper.core.meta.PropertyValueInvoker;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 import com.github.mygreen.sqlmapper.core.query.SetClause;
 import com.github.mygreen.sqlmapper.core.query.WhereClause;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
@@ -194,7 +196,7 @@ public class AutoUpdateExecutor {
 
     /**
      * 更新処理を実行します。
-     * 
+     *
      * @return 更新したレコード件数です。更新対象のプロパティ（カラム）がない場合は {@literal 0} を返します。
      * @throws OptimisticLockingFailureException 楽観的排他制御を行う場合に該当するレコードが存在しない場合にスローされます。
      */
@@ -206,7 +208,7 @@ public class AutoUpdateExecutor {
             return 0;
         }
 
-        final int rows = context.getJdbcTemplate().update(executedSql, paramValues.toArray());
+        final int rows = getJdbcTemplate().update(executedSql, paramValues.toArray());
         if(isOptimisticLock()) {
             validateRows(rows);
         }
@@ -217,6 +219,16 @@ public class AutoUpdateExecutor {
 
         return rows;
 
+    }
+
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(query.getQueryTimeout())
+                .build();
     }
 
     /**

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoUpdateImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoUpdateImpl.java
@@ -48,6 +48,9 @@ public class AutoUpdateImpl<T> implements AutoUpdate<T> {
     @Getter
     private final EntityMeta entityMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
     /**
      * バージョンプロパティを更新対象に含めるかどうか。
      */
@@ -103,6 +106,12 @@ public class AutoUpdateImpl<T> implements AutoUpdate<T> {
                     .paramWithClass("entityType", entityMeta.getEntityType())
                     .format());
         }
+    }
+
+    @Override
+    public AutoUpdateImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCount.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCount.java
@@ -3,10 +3,21 @@ package com.github.mygreen.sqlmapper.core.query.sql;
 /**
  * SQLテンプレートによる件数のカウントを行うクエリです。
  *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
 public interface SqlCount {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    SqlCount queryTimeout(int seconds);
 
     /**
      * カウント用のクエリを実行します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCountImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCountImpl.java
@@ -1,9 +1,12 @@
 package com.github.mygreen.sqlmapper.core.query.sql;
 
+import org.springframework.jdbc.core.JdbcTemplate;
+
 import com.github.mygreen.splate.ProcessResult;
 import com.github.mygreen.splate.SqlTemplate;
 import com.github.mygreen.splate.SqlTemplateContext;
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 
 import lombok.Getter;
 
@@ -34,6 +37,9 @@ public class SqlCountImpl implements SqlCount {
     @Getter
     private final SqlTemplateContext parameter;
 
+    @Getter
+    private Integer queryTimeout;
+
     public SqlCountImpl(SqlMapperContext context, SqlTemplate template, SqlTemplateContext parameter) {
         this.context = context;
         this.template = template;
@@ -41,9 +47,25 @@ public class SqlCountImpl implements SqlCount {
     }
 
     @Override
+    public SqlCountImpl queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
+    }
+
+    @Override
     public long getCount() {
         ProcessResult result = template.process(parameter);
-        return context.getJdbcTemplate().queryForObject(result.getSql(), Long.class, result.getParameters().toArray());
+        return getJdbcTemplate().queryForObject(result.getSql(), Long.class, result.getParameters().toArray());
 
+    }
+
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(queryTimeout)
+                .build();
     }
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelect.java
@@ -9,12 +9,47 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 /**
  * SQLテンプレートによる抽出を行うクエリです。
  *
- *
+ * @version0 .3
  * @author T.TSUCHIE
  *
  * @param <T> 処理対象のエンティティの型
  */
 public interface SqlSelect<T> {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    SqlSelect<T> queryTimeout(int seconds);
+
+    /**
+     * フェッチ数を設定します。
+     * <p>これをデフォルト値よりも高く設定すると、大きな結果セットを処理する際に、メモリ消費を犠牲にして処理速度が向上します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param fetchSize フェッチ数
+     * @return 自身のインスタンス。
+     */
+    SqlSelect<T> fetchSize(int fetchSize);
+
+    /**
+     * 最大行数を設定します。
+     * <p>JDBCのStatementレベルで、結果セットのオブジェクトが含むことのできる最大行数を制限します。
+     *  <br>制限値を超えた場合は通知なしの除外されます。
+     * </p>
+     * <p>RDMSでLIMIT句がサポートされていない場合に使用します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param maxRows 最大行数
+     * @return 自身のインスタンス。
+     */
+    SqlSelect<T> maxRows(int maxRows);
 
     /**
      * 検索してベースオブジェクトを返します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectExecutor.java
@@ -5,11 +5,13 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.github.mygreen.splate.ProcessResult;
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
 import com.github.mygreen.sqlmapper.core.mapper.EntityMappingCallback;
 import com.github.mygreen.sqlmapper.core.mapper.SqlEntityRowMapper;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 
 
 /**
@@ -80,7 +82,7 @@ public class SqlSelectExecutor<T> {
         prepare();
 
         SqlEntityRowMapper<T> rowMapper = new SqlEntityRowMapper<T>(query.getEntityMeta(), Optional.ofNullable(callback));
-        return context.getJdbcTemplate().queryForObject(executedSql, rowMapper, paramValues);
+        return getJdbcTemplate().queryForObject(executedSql, rowMapper, paramValues);
     }
 
     /**
@@ -93,7 +95,7 @@ public class SqlSelectExecutor<T> {
         prepare();
 
         SqlEntityRowMapper<T> rowMapper = new SqlEntityRowMapper<T>(query.getEntityMeta(), Optional.ofNullable(callback));
-        final List<T> ret = context.getJdbcTemplate().query(executedSql, rowMapper, paramValues);
+        final List<T> ret = getJdbcTemplate().query(executedSql, rowMapper, paramValues);
         if(ret.isEmpty()) {
             return Optional.empty();
         } else {
@@ -111,7 +113,7 @@ public class SqlSelectExecutor<T> {
         prepare();
 
         SqlEntityRowMapper<T> rowMapper = new SqlEntityRowMapper<T>(query.getEntityMeta(), Optional.ofNullable(callback));
-        return context.getJdbcTemplate().query(executedSql, rowMapper, paramValues);
+        return getJdbcTemplate().query(executedSql, rowMapper, paramValues);
     }
 
     /**
@@ -123,7 +125,19 @@ public class SqlSelectExecutor<T> {
         prepare();
 
         SqlEntityRowMapper<T> rowMapper = new SqlEntityRowMapper<T>(query.getEntityMeta(), Optional.ofNullable(callback));
-        return context.getJdbcTemplate().queryForStream(executedSql, rowMapper, paramValues);
+        return getJdbcTemplate().queryForStream(executedSql, rowMapper, paramValues);
+    }
+
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(query.getQueryTimeout())
+                .fetchSize(query.getFetchSize())
+                .maxRows(query.getMaxRows())
+                .build();
     }
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectImpl.java
@@ -46,6 +46,15 @@ public class SqlSelectImpl<T> implements SqlSelect<T> {
     @Getter
     private final EntityMeta entityMeta;
 
+    @Getter
+    private Integer queryTimeout;
+
+    @Getter
+    private Integer fetchSize;
+
+    @Getter
+    private Integer maxRows;
+
     public SqlSelectImpl(@NonNull SqlMapperContext context, @NonNull Class<T> baseClass,
             @NonNull SqlTemplate template, @NonNull SqlTemplateContext parameter) {
 
@@ -55,6 +64,24 @@ public class SqlSelectImpl<T> implements SqlSelect<T> {
 
         this.baseClass = baseClass;
         this.entityMeta = context.getEntityMetaFactory().create(baseClass);
+    }
+
+    @Override
+    public SqlSelectImpl<T> queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
+    }
+
+    @Override
+    public SqlSelectImpl<T> fetchSize(int fetchSize) {
+        this.fetchSize = fetchSize;
+        return this;
+    }
+
+    @Override
+    public SqlSelectImpl<T> maxRows(int maxRows) {
+        this.maxRows = maxRows;
+        return this;
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlUpdate.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlUpdate.java
@@ -3,11 +3,21 @@ package com.github.mygreen.sqlmapper.core.query.sql;
 /**
  * SQLテンプレートによる更新（INSERT / UPDATE/ DELETE）を行うクエリです。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
 public interface SqlUpdate {
+
+    /**
+     * クエリタイムアウトの秒数を設定します。
+     * <p>{@literal -1} を指定するとJDBC ドライバーのデフォルト値を使用します。
+     *
+     * @since 0.3
+     * @param seconds クエリタイムアウトの秒数
+     * @return 自身のインスタンス。
+     */
+    SqlUpdate queryTimeout(int seconds);
 
     /**
      * 更新クエリを実行します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlUpdateImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlUpdateImpl.java
@@ -1,9 +1,12 @@
 package com.github.mygreen.sqlmapper.core.query.sql;
 
+import org.springframework.jdbc.core.JdbcTemplate;
+
 import com.github.mygreen.splate.ProcessResult;
 import com.github.mygreen.splate.SqlTemplate;
 import com.github.mygreen.splate.SqlTemplateContext;
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
+import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
 
 import lombok.Getter;
 
@@ -35,6 +38,9 @@ public class SqlUpdateImpl implements SqlUpdate {
     @Getter
     private final SqlTemplateContext parameter;
 
+    @Getter
+    private Integer queryTimeout;
+
     public SqlUpdateImpl(SqlMapperContext context, SqlTemplate template, SqlTemplateContext parameter) {
         this.context = context;
         this.template = template;
@@ -42,9 +48,26 @@ public class SqlUpdateImpl implements SqlUpdate {
     }
 
     @Override
+    public SqlUpdateImpl queryTimeout(int seconds) {
+        this.queryTimeout = seconds;
+        return this;
+    }
+
+    @Override
     public int execute() {
         ProcessResult result = template.process(parameter);
-        return context.getJdbcTemplate().update(result.getSql(), result.getParameters().toArray());
+        return getJdbcTemplate().update(result.getSql(), result.getParameters().toArray());
 
     }
+
+    /**
+     * {@link JdbcTemplate}を取得します。
+     * @return {@link JdbcTemplate}のインスタンス。
+     */
+    private JdbcTemplate getJdbcTemplate() {
+        return JdbcTemplateBuilder.create(context.getDataSource(), context.getJdbcTemplateProperties())
+                .queryTimeout(queryTimeout)
+                .build();
+    }
+
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/sqlmapper.properties
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/sqlmapper.properties
@@ -2,6 +2,12 @@
 # SqlMapperの初期設定値
 ############################################
 
+## JdbcTemplateの初期値設定
+sqlmapper.jdbc-template.fetch-size=-1
+sqlmapper.jdbc-template.max-rows=-1
+sqlmapper.jdbc-template.query-timeout=-1
+sqlmapper.jdbc-template.ignore-warning=true
+
 ## テーブルによる識別子（主キー）の設定
 sqlmapper.table-id-generator.table=ID_SEQUENCE
 sqlmapper.table-id-generator.schema=

--- a/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-autoconfigure/src/main/java/com/github/mygreen/sqlmapper/boot/autoconfigure/SqlMapperProperties.java
+++ b/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-autoconfigure/src/main/java/com/github/mygreen/sqlmapper/boot/autoconfigure/SqlMapperProperties.java
@@ -2,6 +2,7 @@ package com.github.mygreen.sqlmapper.boot.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import com.github.mygreen.sqlmapper.core.config.JdbcTemplateProperties;
 import com.github.mygreen.sqlmapper.core.config.SqlTemplateProperties;
 import com.github.mygreen.sqlmapper.core.config.TableIdGeneratorProperties;
 
@@ -11,11 +12,11 @@ import lombok.Data;
  * SqlMapperの環境設定
  *
  *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
 @Data
-//@PropertySource("classpath:/com/github/mygreen/sqlmapper/core/sqlmapper.properties")
 @ConfigurationProperties(SqlMapperProperties.PREFIX)
 public class SqlMapperProperties {
 
@@ -23,6 +24,11 @@ public class SqlMapperProperties {
      * プロパティファイルの接頭語
      */
     public static final String PREFIX = "sqlmapper";
+
+    /**
+     * {@literal JdbcTemplate}の初期設定値
+     */
+    private JdbcTemplateProperties jdbcTemplate;
 
     /**
      * テーブルによるIDの自動採番の設定値


### PR DESCRIPTION
各クエリごとに、タイムアウトなどを指定できるよう変更。
- JdbcTemplateの初期設定を指定できるように変更。
- クエリ実行単位に、JdbcTemplateのインスタンスを作成するよう変更。
- ID生成時のトランザクションテンプレートのインスタンス作成を都度生成するよう修正。