### PR TITLE
@Column(insertable)の削除/@Table(readOnly)の追加

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/Column.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/Column.java
@@ -25,11 +25,6 @@ public @interface Column {
     String name() default "";
 
     /**
-     * (オプション) 永続化プロバイダによって生成されたSQL INSERTステートメントにカラムが含まれるかどうか。
-     */
-    boolean insertable() default true;
-
-    /**
      * (オプション) 永続化プロバイダによって生成されたSQL UPDATEステートメントにカラムが含まれるかどうか。
      */
     boolean updatable() default true;

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/Table.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/Table.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Target;
  * テーブル情報を指定します。
  * 本アノテーションが指定されていない場合は、デフォルト値が適用されます。
  *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
@@ -36,5 +37,13 @@ public @interface Table {
      * デフォルトの値はエンティティの名前です。
      */
     String name() default "";
+
+    /**
+     * (オプション) テーブルが読み取り専用かどうかを指定します。
+     * <p>この属性の値が {@literal true} のときに、挿入／更新／削除 操作が呼ばれたときエラーとなります。
+     *
+     * @since 0.3
+     */
+    boolean readOnly() default false;
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/messages.properties
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/messages.properties
@@ -50,6 +50,8 @@ query.existsSameJoinEntity=結合先のエンティティ '{toEntity}' は既に
 query.existsSameAssociateEntity=エンティティ '{entity1}' と '{entity2}' の構成定義の組み合わせは既に定義されています。
 query.noExistsTargetAssociateEntity=エンティティ '{entity1}' または '{entity2}' の構成定義は参照対象のエンティティではありません。
 
+query.readOnlyEntity=エンティティ '{entityType}' は読み取り専用であるため、挿入/更新/削除はできません。
+
 sqlTemplate.notReadable=SQLファイル '{path}' は存在しないか読み込めません。
 sqlTemplate.failRead=SQLファイル '{path}' の読み込みに失敗しました。
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/ColumnMeta.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/ColumnMeta.java
@@ -20,13 +20,6 @@ public class ColumnMeta {
     private String name;
 
     /**
-     * 挿入可能かどうか。
-     */
-    @Getter
-    @Setter
-    private boolean insertable = true;
-
-    /**
      * 更新可能かどうか。
      */
     @Getter

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/EntityMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/EntityMetaFactory.java
@@ -141,6 +141,8 @@ public class EntityMetaFactory {
                 tableMeta.setCatalog(annoTable.catalog());
             }
 
+            tableMeta.setReadOnly(annoTable.readOnly());
+
         } else {
             tableMeta.setName(defaultName);
         }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
@@ -248,8 +248,7 @@ public class PropertyMetaFactory {
                 columnMeta.setName(defaultColumnName);
             }
 
-            columnMeta.setInsertable(annoColumn.get().insertable());
-            columnMeta.setUpdatable(annoColumn.get().insertable());
+            columnMeta.setUpdatable(annoColumn.get().updatable());
 
         } else {
             columnMeta.setName(defaultColumnName);

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/TableMeta.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/TableMeta.java
@@ -36,6 +36,13 @@ public class TableMeta {
     private String catalog;
 
     /**
+     * 読み取り専用かどうか。
+     */
+    @Getter
+    @Setter
+    private boolean readOnly = false;
+
+    /**
      * カタログやスキーマを含んだ完全な名前を返します。
      * @return カタログやスキーマを含んだ完全な名前
      */

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoAnyDeleteImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoAnyDeleteImpl.java
@@ -2,6 +2,7 @@ package com.github.mygreen.sqlmapper.core.query.auto;
 
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
 import com.github.mygreen.sqlmapper.core.meta.EntityMeta;
+import com.github.mygreen.sqlmapper.core.query.IllegalOperateException;
 import com.github.mygreen.sqlmapper.metamodel.EntityPath;
 import com.github.mygreen.sqlmapper.metamodel.Predicate;
 
@@ -47,6 +48,19 @@ public class AutoAnyDeleteImpl<T> implements AutoAnyDelete<T> {
         this.entityPath = entityPath;
         this.entityMeta = context.getEntityMetaFactory().create(entityPath.getType());
         this.baseClass = (Class<T>)entityMeta.getEntityType();
+
+        validateTarget();
+    }
+
+    private void validateTarget() {
+
+        // 読み取り専用かどうかのチェック
+        if(entityMeta.getTableMeta().isReadOnly()) {
+            throw new IllegalOperateException(context.getMessageFormatter().create("query.readOnlyEntity")
+                    .paramWithClass("entityType", entityMeta.getEntityType())
+                    .format());
+        }
+
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDeleteImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDeleteImpl.java
@@ -73,6 +73,14 @@ public class AutoBatchDeleteImpl<T> implements AutoBatchDelete<T> {
     }
 
     private void validateTarget() {
+
+        // 読み取り専用かどうかのチェック
+        if(entityMeta.getTableMeta().isReadOnly()) {
+            throw new IllegalOperateException(context.getMessageFormatter().create("query.readOnlyEntity")
+                    .paramWithClass("entityType", entityMeta.getEntityType())
+                    .format());
+        }
+
         // 主キーを持つかどうかのチェック
         if(entityMeta.getIdPropertyMetaList().isEmpty()) {
             throw new IllegalOperateException(context.getMessageFormatter().create("query.requiredId")

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchInsertExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchInsertExecutor.java
@@ -107,9 +107,6 @@ public class AutoBatchInsertExecutor {
         for(PropertyMeta propertyMeta : query.getEntityMeta().getAllColumnPropertyMeta()) {
 
             final String propertyName = propertyMeta.getName();
-            if(!propertyMeta.getColumnMeta().isInsertable()) {
-                continue;
-            }
 
             if(query.getExcludesProperties().contains(propertyName)) {
                 continue;

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchUpdateImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchUpdateImpl.java
@@ -86,6 +86,14 @@ public class AutoBatchUpdateImpl<T> implements AutoBatchUpdate<T> {
     }
 
     private void validateTarget() {
+
+        // 読み取り専用かどうかのチェック
+        if(entityMeta.getTableMeta().isReadOnly()) {
+            throw new IllegalOperateException(context.getMessageFormatter().create("query.readOnlyEntity")
+                    .paramWithClass("entityType", entityMeta.getEntityType())
+                    .format());
+        }
+
         // 主キーを持つかどうかのチェック
         if(entityMeta.getIdPropertyMetaList().isEmpty()) {
             throw new IllegalOperateException(context.getMessageFormatter().create("query.requiredId")

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoDeleteImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoDeleteImpl.java
@@ -63,6 +63,14 @@ public class AutoDeleteImpl<T> implements AutoDelete<T> {
     }
 
     private void validateTarget() {
+
+        // 読み取り専用かどうかのチェック
+        if(entityMeta.getTableMeta().isReadOnly()) {
+            throw new IllegalOperateException(context.getMessageFormatter().create("query.readOnlyEntity")
+                    .paramWithClass("entityType", entityMeta.getEntityType())
+                    .format());
+        }
+
         // 主キーを持つかどうかのチェック
         if(entityMeta.getIdPropertyMetaList().isEmpty()) {
             throw new IllegalOperateException(context.getMessageFormatter().create("query.requiredId")

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsertExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsertExecutor.java
@@ -96,9 +96,6 @@ public class AutoInsertExecutor {
         for(PropertyMeta propertyMeta : query.getEntityMeta().getAllColumnPropertyMeta()) {
 
             final String propertyName = propertyMeta.getName();
-            if(!propertyMeta.getColumnMeta().isInsertable()) {
-                continue;
-            }
 
             if(query.getExcludesProperties().contains(propertyName)) {
                 continue;

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsertImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsertImpl.java
@@ -61,6 +61,19 @@ public class AutoInsertImpl<T> implements AutoInsert<T> {
         this.context = context;
         this.entity = entity;
         this.entityMeta = context.getEntityMetaFactory().create(entity.getClass());
+
+        validateTarget();
+    }
+
+    private void validateTarget() {
+
+        // 読み取り専用かどうかのチェック
+        if(entityMeta.getTableMeta().isReadOnly()) {
+            throw new IllegalOperateException(context.getMessageFormatter().create("query.readOnlyEntity")
+                    .paramWithClass("entityType", entityMeta.getEntityType())
+                    .format());
+        }
+
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoUpdateImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoUpdateImpl.java
@@ -100,6 +100,14 @@ public class AutoUpdateImpl<T> implements AutoUpdate<T> {
     }
 
     private void validateTarget() {
+
+        // 読み取り専用かどうかのチェック
+        if(entityMeta.getTableMeta().isReadOnly()) {
+            throw new IllegalOperateException(context.getMessageFormatter().create("query.readOnlyEntity")
+                    .paramWithClass("entityType", entityMeta.getEntityType())
+                    .format());
+        }
+
         // 主キーを持つかどうかのチェック
         if(entityMeta.getIdPropertyMetaList().isEmpty()) {
             throw new IllegalOperateException(context.getMessageFormatter().create("query.requiredId")


### PR DESCRIPTION
テーブル、カラムの更新属性を整理。

- ``@Column(insertable)`` の削除。
  - 本ライブラリは、JPAのようにリレーションによる挿入などをサポートしていないため不要。
- ``@Table(readOnly)`` の追加。
  - Viewなどの読み取り専用のエンティティに対して挿入・更新・削除を行ったときのチェック処理を追加する。
  - また、読み取り専用かどうか明示するためにも使用する。