### PR TITLE
文字列結合用の関数を追加

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/where/metamodel/MetamodelWhereBuilderTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/where/metamodel/MetamodelWhereBuilderTest.java
@@ -89,6 +89,29 @@ public class MetamodelWhereBuilderTest {
     }
 
     @Test
+    void testStringConcat() {
+
+        MCustomer entity = MCustomer.customer;
+        Predicate condition = entity.firstName.concat(entity.lastName).like("yama");
+
+        EntityMeta entityMeta = entityMetaFactory.create(Customer.class);
+
+        TableNameResolver tableNameResolver = new TableNameResolver();
+        tableNameResolver.prepareTableAlias(entity);
+
+        MetamodelWhereVisitor visitor = new MetamodelWhereVisitor(Map.of(entityMeta.getEntityType(), entityMeta),
+                 dialect, entityMetaFactory, tableNameResolver);
+        visitor.visit(new MetamodelWhere(condition));
+
+        String sql = visitor.getCriteria();
+        assertThat(sql).isEqualTo("concat(T1_.FIRST_NAME, T1_.LAST_NAME) like ?");
+
+        List<Object> params = visitor.getParamValues();
+        assertThat(params).containsExactly("yama");
+
+    }
+
+    @Test
     void test_arithmetic() {
         MCustomer entity = MCustomer.customer;
         Predicate condition = entity.firstName.lower().contains("taro")

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/StringExpression.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/StringExpression.java
@@ -29,6 +29,7 @@ public abstract class StringExpression extends ComparableExpression<String> {
 
     /**
      * {@literal 左辺 LIKE 右辺} として比較する式を作成します。
+     * @since 0.3
      * @param str LIKE検索対象の文字列。特殊文字のエスケープは予め実施しておく必要があります。
      * @param escape エスケープ文字。
      * @return {@literal 左辺 LIKE 右辺}
@@ -48,6 +49,7 @@ public abstract class StringExpression extends ComparableExpression<String> {
 
     /**
      * {@literal 左辺 LIKE 右辺} として比較する式を作成します。
+     * @since 0.3
      * @param str LIKE検索対象の文字列。特殊文字のエスケープは予め実施しておく必要があります。
      * @param escape エスケープ文字。
      * @return {@literal 左辺 LIKE 右辺}
@@ -67,6 +69,7 @@ public abstract class StringExpression extends ComparableExpression<String> {
 
     /**
      * 部分一致 {@literal 左辺 LIKE %右辺%} として比較する式を作成します。
+     * @since 0.3
      * @param str 検索対象の文字列。
      * @param escape エスケープ文字。
      * @return {@literal 左辺 LIKE %右辺%}
@@ -86,6 +89,7 @@ public abstract class StringExpression extends ComparableExpression<String> {
 
     /**
      * 部分一致 {@literal 左辺 LIKE %右辺%} として比較する式を作成します。
+     * @since 0.3
      * @param str 検索対象の文字列。
      * @param escape エスケープ文字。
      * @return {@literal 左辺 LIKE %右辺%}
@@ -105,6 +109,7 @@ public abstract class StringExpression extends ComparableExpression<String> {
 
     /**
      * 前方一致 {@literal 左辺 LIKE %右辺} として比較する式を作成します。
+     * @since 0.3
      * @param str 検索対象の文字列。
      * @param escape エスケープ文字。
      * @return {@literal 左辺 LIKE %右辺}
@@ -124,6 +129,7 @@ public abstract class StringExpression extends ComparableExpression<String> {
 
     /**
      * 前方一致 {@literal 左辺 LIKE %右辺} として比較する式を作成します。
+     * @since 0.3
      * @param str 検索対象の文字列。
      * @param escape エスケープ文字。
      * @return {@literal 左辺 LIKE %右辺}
@@ -163,12 +169,13 @@ public abstract class StringExpression extends ComparableExpression<String> {
 
     /**
      * 後方一致 {@literal 左辺 LIKE 右辺%} として比較する式を作成します。
+     * @since 0.3
      * @param str 検索対象の文字列。
      * @param escape エスケープ文字。
      * @return {@literal 左辺 LIKE 右辺%}
      */
     protected BooleanExpression ends(Expression<String> str, char escape) {
-        return new BooleanOperation(LikeOp.ENDS, mixin, str,  Constant.createChar(escape));
+        return new BooleanOperation(LikeOp.ENDS, mixin, str, Constant.createChar(escape));
     }
 
     /**
@@ -185,5 +192,25 @@ public abstract class StringExpression extends ComparableExpression<String> {
      */
     public StringExpression upper() {
         return new StringOperation(FunctionOp.UPPER, mixin);
+    }
+
+    /**
+     * 文字列を結合します。
+     * @since 0.3
+     * @param str 結合する文字列。
+     * @return {@literal CONCAT(左辺, 右辺)}
+     */
+    public StringExpression concat(String str) {
+        return new StringOperation(FunctionOp.CONCAT, mixin, Constant.createString(str));
+    }
+
+    /**
+     * 文字列を結合します。
+     * @since 0.3
+     * @param str 結合する文字列。
+     * @return {@literal CONCAT(左辺, 右辺)}
+     */
+    public StringExpression concat(Expression<String> str) {
+        return new StringOperation(FunctionOp.CONCAT, mixin, str);
     }
 }

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/operator/FunctionOp.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/operator/FunctionOp.java
@@ -13,6 +13,7 @@ public enum FunctionOp implements Operator {
     // String
     LOWER(String.class, -1),
     UPPER(String.class, -1),
+    CONCAT(String.class, -1),
 
     // Date/Time
     CURRENT_DATE(Comparable.class, -1),


### PR DESCRIPTION
- 文字列結合用の関数 ``concat`` を追加。
- ``||`` でもよかったが、汎用的な関数型で実装。
