### PR TITLE
SQL関数の処理を関数ごとに分割

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/Dialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/Dialect.java
@@ -1,6 +1,7 @@
 package com.github.mygreen.sqlmapper.core.dialect;
 
 import java.sql.ResultSet;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -10,11 +11,13 @@ import com.github.mygreen.splate.SqlTemplateEngine;
 import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
 import com.github.mygreen.sqlmapper.core.query.SelectForUpdateType;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
+import com.github.mygreen.sqlmapper.core.where.metamodel.OperationHandler;
+import com.github.mygreen.sqlmapper.metamodel.operator.Operator;
 
 /**
  * SQLの方言を定義します。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
@@ -104,4 +107,13 @@ public interface Dialect {
      * @return {@literal true}のとき、{@link ResultSet} に対してパラメータが必要です。
      */
     boolean needsParameterForResultSet();
+
+    /**
+     * メタモデルの条件式を評価する処理のマップを返します。
+     * <p>デフォルトの実装から変更するものみ設定します。
+     *
+     * @since 0.3
+     * @return メタモデルの条件式を評価する処理のマップ
+     */
+    Map<Class<?>, OperationHandler<? extends Operator>> getOperationHandlerMap();
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/DialectBase.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/DialectBase.java
@@ -1,10 +1,17 @@
 package com.github.mygreen.sqlmapper.core.dialect;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.lang.Nullable;
 
 import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
 import com.github.mygreen.sqlmapper.core.query.SelectForUpdateType;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
+import com.github.mygreen.sqlmapper.core.where.metamodel.OperationHandler;
+import com.github.mygreen.sqlmapper.metamodel.operator.Operator;
+
+import lombok.Getter;
 
 /**
  * {@link Dialect}のベースとなるクラス。
@@ -15,6 +22,12 @@ import com.github.mygreen.sqlmapper.core.type.ValueType;
  *
  */
 public abstract class DialectBase implements Dialect {
+
+    /**
+     * メタモデルによる各演算子の処理のマップ。
+     */
+    @Getter
+    protected Map<Class<?>, OperationHandler<? extends Operator>> operationHandlerMap = new HashMap<>();
 
     /**
      * {@inheritDoc}
@@ -98,6 +111,19 @@ public abstract class DialectBase implements Dialect {
     @Override
     public boolean needsParameterForResultSet() {
         return false;
+    }
+
+    /**
+     * メタモデルに対する演算子に対する処理を登録します。
+     * <p>登録する際に、{@literal OperationHandler#init()}を実行します。
+     *
+     * @since 0.3
+     * @param <T> 演算子の種別
+     * @param operatorClass 演算子種別のクラス
+     * @param handler 演算子に対する処理
+     */
+    public <T extends Operator> void register(Class<T> operatorClass,  OperationHandler<T> handler) {
+        this.operationHandlerMap.put(operatorClass, handler);
     }
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/SqliteDialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/SqliteDialect.java
@@ -5,15 +5,26 @@ import javax.sql.DataSource;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
 
 import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+import com.github.mygreen.sqlmapper.core.where.metamodel.FuncOpHandler;
+import com.github.mygreen.sqlmapper.core.where.metamodel.function.OperatorConcatFunction;
+import com.github.mygreen.sqlmapper.metamodel.operator.FunctionOp;
 
 /**
  * SQLiteの方言の定義。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
 public class SqliteDialect extends DialectBase {
+
+    public SqliteDialect() {
+
+        // SQL関数のカスタマイズ
+        FuncOpHandler funcHandler = new FuncOpHandler();
+        funcHandler.register(FunctionOp.CONCAT, new OperatorConcatFunction());
+        register(FunctionOp.class, funcHandler);
+    }
 
     /**
      * {@inheritDoc}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ExpressionEvaluator.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ExpressionEvaluator.java
@@ -1,0 +1,35 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel;
+
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+import com.github.mygreen.sqlmapper.metamodel.operator.FunctionOp;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 演算子を評価するための処理。
+ * <p>SQL関数を評価する際にサブ式を評価するために使用します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+@RequiredArgsConstructor
+public class ExpressionEvaluator {
+
+    private final FunctionOp operator;
+
+    private final OperationHandler<?> handler;
+
+    /**
+     * 式ノードを評価し、SQLを組み立てます。
+     *
+     * @param expr 評価対象の式
+     * @param visitor Visitor
+     * @param context コンテキスト
+     */
+    public void evaluate(Expression<?> expr, Visitor<VisitorContext> visitor, VisitorContext context) {
+        this.handler.invoke(operator, expr, visitor, context);
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ExpressionVisitor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ExpressionVisitor.java
@@ -46,15 +46,28 @@ import com.github.mygreen.sqlmapper.metamodel.operator.UnaryOp;
  */
 public class ExpressionVisitor implements Visitor<VisitorContext> {
 
-    private Map<Class<?>, OperationHandler<? extends Operator>> operationHandlerMap;
-    {
-        this.operationHandlerMap = new HashMap<>();
-        operationHandlerMap.put(BooleanOp.class, new BooleanOpHandler());
-        operationHandlerMap.put(UnaryOp.class, new UnaryOpHandler());
-        operationHandlerMap.put(ComparisionOp.class, new ComparisionOpHandler());
-        operationHandlerMap.put(LikeOp.class, new LikeOpHandler());
-        operationHandlerMap.put(FunctionOp.class, new FuncOpHandler());
-        operationHandlerMap.put(ArithmeticOp.class, new ArithmeticOpHandler());
+    private Map<Class<?>, OperationHandler<? extends Operator>> operationHandlerMap = new HashMap<>();
+
+    public ExpressionVisitor() {
+        register(BooleanOp.class, new BooleanOpHandler());
+        register(UnaryOp.class, new UnaryOpHandler());
+        register(ComparisionOp.class, new ComparisionOpHandler());
+        register(LikeOp.class, new LikeOpHandler());
+        register(FunctionOp.class, new FuncOpHandler());
+        register(ArithmeticOp.class, new ArithmeticOpHandler());
+    }
+
+    /**
+     * 演算子に対する処理を登録します。
+     * <p>登録する際に、{@literal OperationHandler#init()}を実行します。
+     *
+     * @param <T> 演算子の種別
+     * @param operatorClass 演算子種別のクラス
+     * @param handler 演算子に対する処理
+     */
+    public <T extends Operator> void register(Class<T> operatorClass,  OperationHandler<T> handler) {
+        handler.init();
+        this.operationHandlerMap.put(operatorClass, handler);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/FuncOpHandler.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/FuncOpHandler.java
@@ -54,10 +54,11 @@ public class FuncOpHandler extends OperationHandler<FunctionOp> {
     public void handle(FunctionOp operator, Operation<?> expr, Visitor<VisitorContext> visitor, VisitorContext context) {
 
         SqlFunction function = functionMap.get(operator);
-        if(function != null) {
-            function.handle(expr.getArgs(), visitor, context, new ExpressionEvaluator(operator, this));
-            return;
+        if(function == null) {
+            throw new IllegalArgumentException("not support operator=" + operator);
         }
+
+        function.handle(expr.getArgs(), visitor, context, new ExpressionEvaluator(operator, this));
 
     }
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/MetamodelWhereVisitor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/MetamodelWhereVisitor.java
@@ -67,6 +67,7 @@ public class MetamodelWhereVisitor implements WhereVisitor {
 
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private synchronized void visit(MetamodelWhere where) {
 
         synchronized (visitorContext) {
@@ -76,6 +77,10 @@ public class MetamodelWhereVisitor implements WhereVisitor {
             // Metamodel用のVisitorに委譲する
             VisitorContext context = new VisitorContext(entityMetaMap, dialect, entityMetaFactory, tableNameResolver);
             ExpressionVisitor visitor = new ExpressionVisitor();
+
+            // DBごとにカスタマイズされた演算子の処理の登録
+            dialect.getOperationHandlerMap().forEach((k, v) -> visitor.register((Class)k, v));
+
             where.getPredicate().accept(visitor, context);
 
             // 結果を格納する

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/OperationHandler.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/OperationHandler.java
@@ -36,10 +36,6 @@ public abstract class OperationHandler<T extends Operator> {
      */
     protected Map<T, String> templateMap = new HashMap<>();
 
-    public OperationHandler() {
-        init();
-    }
-
     /**
      * 初期化処理
      */

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/SqlFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/SqlFunction.java
@@ -1,0 +1,29 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+
+/**
+ * SQL関数を処理するためのインタフェース。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+@FunctionalInterface
+public interface SqlFunction {
+
+    /**
+     * SQL関数を処理します。
+     *
+     * @param args 関数の引数。
+     * @param visitor 式ノードを巡回するためのVisitor。
+     * @param context 組み立てたSQL情報を保持します。
+     * @param evaluator 式を評価する処理
+     */
+    void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor, VisitorContext context,
+            ExpressionEvaluator evaluator);
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/ConcatFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/ConcatFunction.java
@@ -1,0 +1,45 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.ExpressionEvaluator;
+import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+
+/**
+ * {@literal CONCAT} 関数を処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class ConcatFunction implements SqlFunction {
+
+    @Override
+    public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor, VisitorContext context,
+            ExpressionEvaluator evaluator) {
+
+        // 左辺の評価
+        Expression<?> left = args.get(0);
+        VisitorContext leftContext = new VisitorContext(context);
+        evaluator.evaluate(left, visitor, leftContext);
+
+        // 右辺の評価
+        Expression<?> right = args.get(1);
+        VisitorContext rightContext = new VisitorContext(context);
+        evaluator.evaluate(right, visitor, rightContext);
+
+        // 評価した結果を親のコンテキストに追加する
+        context.appendSql("concat(")
+            .append(leftContext.getCriteria())
+            .append(", ")
+            .append(rightContext.getCriteria())
+            .append(")");
+
+        context.addParamValues(leftContext.getParamValues());
+        context.addParamValues(rightContext.getParamValues());
+
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CurrentDateFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CurrentDateFunction.java
@@ -1,0 +1,27 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.ExpressionEvaluator;
+import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+
+/**
+ * {@literal CURRENT_DATE} 関数を処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class CurrentDateFunction implements SqlFunction {
+
+    @Override
+    public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor, VisitorContext context,
+            ExpressionEvaluator invoker) {
+
+        context.appendSql("current_date");
+
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CurrentTimeFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CurrentTimeFunction.java
@@ -1,0 +1,47 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.ExpressionEvaluator;
+import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Constant;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+
+/**
+ * {@literal CURRENT_TIME} 関数を処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class CurrentTimeFunction implements SqlFunction {
+
+    @Override
+    public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor, VisitorContext context,
+            ExpressionEvaluator invoker) {
+
+        context.appendSql("current_time");
+        doPrecision(args, context);
+
+    }
+
+    /**
+     * 時間の制度が指定されていれば処理を行う。
+     * @param expr 演算子の式
+     * @param context コンテキスト
+     */
+    @SuppressWarnings("unchecked")
+    private void doPrecision(List<Expression<?>> args, VisitorContext context) {
+
+        if(args.isEmpty()) {
+            return;
+        }
+
+        int precision = (int)((Constant<Integer>)args.get(0)).getValue();
+        context.appendSql("(").append(precision).append(")");
+
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CurrentTimestampFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CurrentTimestampFunction.java
@@ -1,0 +1,46 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.ExpressionEvaluator;
+import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Constant;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+
+/**
+ * {@literal CURRENT_TIMESTAMP} 関数を処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class CurrentTimestampFunction implements SqlFunction {
+
+    @Override
+    public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor, VisitorContext context,
+            ExpressionEvaluator invoker) {
+
+        context.appendSql("current_timestamp");
+        doPrecision(args, context);
+
+    }
+
+    /**
+     * 時間の制度が指定されていれば処理を行う。
+     * @param expr 演算子の式
+     * @param context コンテキスト
+     */
+    @SuppressWarnings("unchecked")
+    private void doPrecision(List<Expression<?>> args, VisitorContext context) {
+
+        if(args.isEmpty()) {
+            return;
+        }
+
+        int precision = (int)((Constant<Integer>)args.get(0)).getValue();
+        context.appendSql("(").append(precision).append(")");
+
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/LowerFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/LowerFunction.java
@@ -1,0 +1,30 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.ExpressionEvaluator;
+import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+
+/**
+ * {@literal LOWER} 関数を処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class LowerFunction implements SqlFunction {
+
+    @Override
+    public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor, VisitorContext context,
+            ExpressionEvaluator evaluator) {
+
+        context.appendSql("lower(");
+        evaluator.evaluate(args.get(0), visitor, context);
+        context.appendSql(")");
+
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/OperatorConcatFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/OperatorConcatFunction.java
@@ -1,0 +1,45 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.ExpressionEvaluator;
+import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+
+/**
+ * 演算子 {@literal ||} による文字列結合を処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class OperatorConcatFunction implements SqlFunction {
+
+    @Override
+    public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor, VisitorContext context,
+            ExpressionEvaluator evaluator) {
+
+        // 左辺の評価
+        Expression<?> left = args.get(0);
+        VisitorContext leftContext = new VisitorContext(context);
+        evaluator.evaluate(left, visitor, leftContext);
+
+        // 右辺の評価
+        Expression<?> right = args.get(1);
+        VisitorContext rightContext = new VisitorContext(context);
+        evaluator.evaluate(right, visitor, rightContext);
+
+        // 評価した結果を親のコンテキストに追加する
+        context.appendSql("(")
+            .append(leftContext.getCriteria())
+            .append(" || ")
+            .append(rightContext.getCriteria())
+            .append(")");
+
+        context.addParamValues(leftContext.getParamValues());
+        context.addParamValues(rightContext.getParamValues());
+
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/UpperFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/UpperFunction.java
@@ -1,0 +1,31 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.ExpressionEvaluator;
+import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+
+/**
+ * {@literal UPPER} 関数を処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+
+public class UpperFunction implements SqlFunction {
+
+    @Override
+    public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor, VisitorContext context,
+            ExpressionEvaluator evaluator) {
+
+        context.appendSql("upper(");
+        evaluator.evaluate(args.get(0), visitor, context);
+        context.appendSql(")");
+
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/package-info.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SQL関数の評価処理の実装
+ */
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;


### PR DESCRIPTION
- SQL関数の処理を関数ごとに分割し、Dialectごとにカスタマイズできるように変更。
- SQLiteの場合、文字列結合は、演算子 ``||`` を使用するよう変更。