### PR TITLE
任意のSQL関数を指定できる機能を追加

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/FuncOpHandler.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/FuncOpHandler.java
@@ -7,6 +7,7 @@ import com.github.mygreen.sqlmapper.core.where.metamodel.function.ConcatFunction
 import com.github.mygreen.sqlmapper.core.where.metamodel.function.CurrentDateFunction;
 import com.github.mygreen.sqlmapper.core.where.metamodel.function.CurrentTimeFunction;
 import com.github.mygreen.sqlmapper.core.where.metamodel.function.CurrentTimestampFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.function.CustomFunction;
 import com.github.mygreen.sqlmapper.core.where.metamodel.function.LowerFunction;
 import com.github.mygreen.sqlmapper.core.where.metamodel.function.UpperFunction;
 import com.github.mygreen.sqlmapper.metamodel.Visitor;
@@ -48,6 +49,8 @@ public class FuncOpHandler extends OperationHandler<FunctionOp> {
         register(FunctionOp.CURRENT_DATE, new CurrentDateFunction());
         register(FunctionOp.CURRENT_TIME, new CurrentTimeFunction());
         register(FunctionOp.CURRENT_TIMESTAMP, new CurrentTimestampFunction());
+
+        register(FunctionOp.CUSTOM, new CustomFunction());
     }
 
     @Override

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CustomFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CustomFunction.java
@@ -1,0 +1,71 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.ExpressionEvaluator;
+import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
+import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
+import com.github.mygreen.sqlmapper.core.where.metamodel.function.SqlFunctionTokenizer.TokenType;
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.Constant;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+import com.github.mygreen.sqlmapper.metamodel.operation.CustomFunctionOperation;
+
+/**
+ * 任意の関数を処理します。
+ *
+ *
+ * @author T.TSUCHIE
+ *
+ */
+public class CustomFunction implements SqlFunction {
+
+    @Override
+    public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor,
+            VisitorContext context, ExpressionEvaluator evaluator) {
+
+        // 左辺の評価
+        Expression<?> left = args.get(0);
+        VisitorContext leftContext = new VisitorContext(context);
+        evaluator.evaluate(left, visitor, leftContext);
+
+        CustomFunctionOperation op = (CustomFunctionOperation) args.get(1);
+
+        String query = op.getQuery();
+
+        // クエリを軸解析して、置換していく。
+        SqlFunctionTokenizer tokenizer = new SqlFunctionTokenizer(query);
+        while(TokenType.EOF != tokenizer.next()) {
+            TokenType currentToken =tokenizer.getTokenType();
+            if(currentToken == TokenType.SQL) {
+                context.appendSql(tokenizer.getToken());
+
+            } else if(currentToken == TokenType.THIS_VARIABLE) {
+                context.appendSql(leftContext.getCriteria());
+                context.addParamValues(leftContext.getParamValues());
+
+            } else if(currentToken == TokenType.BIND_VARIABLE) {
+                int varIndex = tokenizer.getBindBariableNum() - 1;
+                Expression<?> arg = op.getArg(varIndex);
+
+                VisitorContext argContext = new VisitorContext(context);
+                evaluator.evaluate(arg, visitor, argContext);
+
+                if(arg instanceof Constant) {
+                    // 定数の場合はプレースホルダーとして変数として追加
+                    context.appendSql("?");
+                } else {
+                    context.appendSql(argContext.getCriteria());
+                }
+
+                context.addParamValues(argContext.getParamValues());
+
+            } else {
+                // unknown
+            }
+        }
+
+    }
+
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CustomFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CustomFunction.java
@@ -7,7 +7,6 @@ import com.github.mygreen.sqlmapper.core.where.metamodel.SqlFunction;
 import com.github.mygreen.sqlmapper.core.where.metamodel.VisitorContext;
 import com.github.mygreen.sqlmapper.core.where.metamodel.function.SqlFunctionTokenizer.TokenType;
 import com.github.mygreen.sqlmapper.metamodel.Visitor;
-import com.github.mygreen.sqlmapper.metamodel.expression.Constant;
 import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
 import com.github.mygreen.sqlmapper.metamodel.operation.CustomFunctionOperation;
 
@@ -51,13 +50,7 @@ public class CustomFunction implements SqlFunction {
                 VisitorContext argContext = new VisitorContext(context);
                 evaluator.evaluate(arg, visitor, argContext);
 
-                if(arg instanceof Constant) {
-                    // 定数の場合はプレースホルダーとして変数として追加
-                    context.appendSql("?");
-                } else {
-                    context.appendSql(argContext.getCriteria());
-                }
-
+                context.appendSql(argContext.getCriteria());
                 context.addParamValues(argContext.getParamValues());
 
             } else {

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CustomFunction.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/CustomFunction.java
@@ -13,7 +13,7 @@ import com.github.mygreen.sqlmapper.metamodel.operation.CustomFunctionOperation;
 /**
  * 任意の関数を処理します。
  *
- *
+ * @since 0.3
  * @author T.TSUCHIE
  *
  */
@@ -23,10 +23,10 @@ public class CustomFunction implements SqlFunction {
     public void handle(List<Expression<?>> args, Visitor<VisitorContext> visitor,
             VisitorContext context, ExpressionEvaluator evaluator) {
 
-        // 左辺の評価
-        Expression<?> left = args.get(0);
-        VisitorContext leftContext = new VisitorContext(context);
-        evaluator.evaluate(left, visitor, leftContext);
+        // 自身プロパティの評価
+        Expression<?> thisExp = args.get(0);
+        VisitorContext thisContext = new VisitorContext(context);
+        evaluator.evaluate(thisExp, visitor, thisContext);
 
         CustomFunctionOperation op = (CustomFunctionOperation) args.get(1);
 
@@ -40,8 +40,8 @@ public class CustomFunction implements SqlFunction {
                 context.appendSql(tokenizer.getToken());
 
             } else if(currentToken == TokenType.THIS_VARIABLE) {
-                context.appendSql(leftContext.getCriteria());
-                context.addParamValues(leftContext.getParamValues());
+                context.appendSql(thisContext.getCriteria());
+                context.addParamValues(thisContext.getParamValues());
 
             } else if(currentToken == TokenType.BIND_VARIABLE) {
                 int varIndex = tokenizer.getBindBariableNum() - 1;

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/SqlFunctionTokenizer.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/SqlFunctionTokenizer.java
@@ -1,0 +1,295 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+/**
+ * SQL関数の字句解析処理。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class SqlFunctionTokenizer {
+
+    /**
+     * トークンの種類
+     *
+     */
+    public enum TokenType {
+        SQL,
+        THIS_VARIABLE,
+        BIND_VARIABLE,
+        EOF
+    }
+
+    /**
+     * 解析対象のSQL
+     */
+    private String sql;
+
+    /**
+     * 現在解析しているポジション
+     */
+    private int position = 0;
+
+    /**
+     * トークン
+     */
+    private String token;
+
+    /**
+     * 現在のトークン種別
+     */
+    private TokenType tokenType = TokenType.SQL;
+
+    /**
+     * 次のトークン種別
+     */
+    private TokenType nextTokenType = TokenType.SQL;
+
+    /**
+     * 現在まで出現したバイド変数の個数
+     */
+    private int bindVariableNum = 0;
+
+    public SqlFunctionTokenizer(String sql) {
+        this.sql = sql;
+    }
+
+    /**
+     * @return SQLを返します。
+     */
+    public String getSql() {
+        return sql;
+    }
+
+    /**
+     * @return 現在解析しているポジションを返します。
+     */
+    public int getPosition() {
+        return position;
+    }
+
+    /**
+     * @return トークンを返します。
+     */
+    public String getToken() {
+        return token;
+    }
+
+    /**
+     * @return 現在解析しているポジションより前のSQLを返します。
+     */
+    public String getBefore() {
+        return sql.substring(0, position);
+    }
+
+    /**
+     * @return 現在解析しているポジションより後ろのSQLを返します。
+     */
+    public String getAfter() {
+        return sql.substring(position);
+    }
+
+    /**
+     * @return 現在のトークン種別を返します。
+     */
+    public TokenType getTokenType() {
+        return tokenType;
+    }
+
+    /**
+     * @return 次のトークン種別を返します。
+     */
+    public TokenType getNextTokenType() {
+        return nextTokenType;
+    }
+
+
+    /**
+     * @return 次のトークンに進みます。
+     */
+    public TokenType next() {
+        if (position >= sql.length()) {
+            token = null;
+            tokenType = TokenType.EOF;
+            nextTokenType = TokenType.EOF;
+            return tokenType;
+        }
+        switch (nextTokenType) {
+        case SQL:
+            parseSql();
+            break;
+        case THIS_VARIABLE:
+            parseThisVariable();
+            break;
+        case BIND_VARIABLE:
+            parseBindVariable();
+            break;
+        default:
+            parseEof();
+            break;
+        }
+        return tokenType;
+    }
+
+    /**
+     * Parse the SQL.
+     */
+    protected void parseSql() {
+
+        int thisVariableStartPos = sql.indexOf("$this", position);
+        int bindVariableStartPos = sql.indexOf("?", position);
+        int nextStartPos = getNextStartPos(thisVariableStartPos, bindVariableStartPos);
+
+        if (nextStartPos < 0) {
+            // 特定のトークンでない場合は、すべてSQL区分する。
+            token = sql.substring(position);
+            nextTokenType = TokenType.EOF;
+            position = sql.length();
+            tokenType = TokenType.SQL;
+
+        } else {
+            token = sql.substring(position, nextStartPos);
+            tokenType = TokenType.SQL;
+            boolean needNext = nextStartPos == position;
+
+            if (nextStartPos == thisVariableStartPos) {
+                nextTokenType = TokenType.THIS_VARIABLE;
+                position = thisVariableStartPos + 4;
+
+            } else if (nextStartPos == bindVariableStartPos) {
+                nextTokenType = TokenType.BIND_VARIABLE;
+                position = bindVariableStartPos;
+            }
+
+            if (needNext) {
+                next();
+            }
+        }
+    }
+
+    /**
+     * 次のトークンの開始位置を返します。
+     *
+     * @param thisVariableStartPos {@literal $this} 変数の開始位置
+     * @param bindVariableStartPos {@literal ?} 変数の開始位置
+     * @return 次のトークンの開始位置。特定のトークンでない場合は {@literal -1} を返します。
+     */
+    protected int getNextStartPos(int thisVariableStartPos, int bindVariableStartPos) {
+
+        int nextStartPos = -1;
+        if (thisVariableStartPos >= 0) {
+            nextStartPos = thisVariableStartPos;
+        }
+
+        if (bindVariableStartPos >= 0
+                && (nextStartPos < 0 || bindVariableStartPos < nextStartPos)) {
+            nextStartPos = bindVariableStartPos;
+        }
+        return nextStartPos;
+    }
+
+    /**
+     * {@literal $this} 変数をパースします。
+     */
+    protected void parseThisVariable() {
+        token = "$this";
+        nextTokenType = TokenType.SQL;
+        position += 1;
+        tokenType = TokenType.THIS_VARIABLE;
+    }
+
+    /**
+     * Parse the bind variable.
+     */
+    protected void parseBindVariable() {
+        token = "?";
+        bindVariableNum++;
+        nextTokenType = TokenType.SQL;
+        position += 1;
+        tokenType = TokenType.BIND_VARIABLE;
+    }
+
+    /**
+     * Parse the end of the SQL.
+     */
+    protected void parseEof() {
+        token = null;
+        tokenType = TokenType.EOF;
+        nextTokenType = TokenType.EOF;
+    }
+
+    /**
+     * バインド変数の現在までの出現回数を取得します。
+     * @return バインド変数の現在までの出現回
+     */
+    public int getBindBariableNum() {
+        return bindVariableNum;
+    }
+
+    /**
+     * トークンをスキップします。
+     *
+     * @return スキップしたトークン
+     */
+    public String skipToken() {
+        int index = sql.length();
+        char quote = position < sql.length() ? sql.charAt(position) : '\0';
+        boolean quoting = quote == '\'' || quote == '(';
+        if (quote == '(') {
+            quote = ')';
+        }
+        for (int i = quoting ? position + 1 : position; i < sql.length(); ++i) {
+            char c = sql.charAt(i);
+            if ((Character.isWhitespace(c) || c == ',' || c == ')' || c == '(')
+                    && !quoting) {
+                index = i;
+                break;
+            } else if (c == '/' && i + 1 < sql.length()
+                    && sql.charAt(i + 1) == '*') {
+                index = i;
+                break;
+            } else if (c == '-' && i + 1 < sql.length()
+                    && sql.charAt(i + 1) == '-') {
+                index = i;
+                break;
+            } else if (quoting && quote == '\'' && c == '\''
+                    && (i + 1 >= sql.length() || sql.charAt(i + 1) != '\'')) {
+                index = i + 1;
+                break;
+            } else if (quoting && c == quote) {
+                index = i + 1;
+                break;
+            }
+        }
+        token = sql.substring(position, index);
+        tokenType = TokenType.SQL;
+        nextTokenType = TokenType.SQL;
+        position = index;
+        return token;
+    }
+
+    /**
+     * ホワイトスペースをスキップします。
+     *
+     * @return スキップしたホワイストスペース
+     */
+    public String skipWhitespace() {
+        int index = skipWhitespace(position);
+        token = sql.substring(position, index);
+        position = index;
+        return token;
+    }
+
+    private int skipWhitespace(int position) {
+        int index = sql.length();
+        for (int i = position; i < sql.length(); ++i) {
+            char c = sql.charAt(i);
+            if (!Character.isWhitespace(c)) {
+                index = i;
+                break;
+            }
+        }
+        return index;
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/SqlFunctionTokenizerTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/where/metamodel/function/SqlFunctionTokenizerTest.java
@@ -1,0 +1,53 @@
+package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.mygreen.sqlmapper.core.where.metamodel.function.SqlFunctionTokenizer.TokenType;
+
+
+public class SqlFunctionTokenizerTest {
+
+    @Test
+    void testParse() {
+        SqlFunctionTokenizer tokenizer = new SqlFunctionTokenizer("custom_test($this, ?)");
+
+        {
+            TokenType type = tokenizer.next();
+            assertThat(type).isEqualTo(TokenType.SQL);
+            String sql = tokenizer.getToken();
+            assertThat(sql).isEqualTo("custom_test(");
+        }
+
+        {
+            TokenType type = tokenizer.next();
+            assertThat(type).isEqualTo(TokenType.THIS_VARIABLE);
+            String sql = tokenizer.getToken();
+            assertThat(sql).isEqualTo("$this");
+        }
+
+        {
+            TokenType type = tokenizer.next();
+            assertThat(type).isEqualTo(TokenType.SQL);
+            String sql = tokenizer.getToken();
+            assertThat(sql).isEqualTo(", ");
+        }
+
+        {
+            TokenType type = tokenizer.next();
+            assertThat(type).isEqualTo(TokenType.BIND_VARIABLE);
+            String sql = tokenizer.getToken();
+            assertThat(sql).isEqualTo("?");
+            assertThat(tokenizer.getBindBariableNum()).isEqualTo(1);
+        }
+
+        {
+            TokenType type = tokenizer.next();
+            assertThat(type).isEqualTo(TokenType.SQL);
+            String sql = tokenizer.getToken();
+            assertThat(sql).isEqualTo(")");
+        }
+
+    }
+}

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/CustomFuntionExpression.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/CustomFuntionExpression.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.github.mygreen.sqlmapper.metamodel.operation.BooleanOperation;
-import com.github.mygreen.sqlmapper.metamodel.operation.EnumOperation;
 import com.github.mygreen.sqlmapper.metamodel.operation.LocalDateOperation;
 import com.github.mygreen.sqlmapper.metamodel.operation.LocalDateTimeOperation;
 import com.github.mygreen.sqlmapper.metamodel.operation.LocalTimeOperation;
@@ -194,12 +193,12 @@ public abstract class CustomFuntionExpression<T> implements Expression<T> {
         return new UtilDateOperation(FunctionOp.CUSTOM, mixin, this);
     }
 
-    /**
-     * 関数の戻り値の型を返します。
-     * @return 列挙型を返します。
-     */
-    public <R extends Enum<R>> EnumExpression<R> returnEnum(Class<R> type) {
-        return new EnumOperation<R>(type, FunctionOp.CUSTOM, mixin, this);
-    }
+//    /**
+//     * 関数の戻り値の型を返します。
+//     * @return 列挙型を返します。
+//     */
+//    public <R extends Enum<R>> EnumExpression<R> returnEnum(Class<R> type) {
+//        return new EnumOperation<R>(type, FunctionOp.CUSTOM, mixin, this);
+//    }
 
 }

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/CustomFuntionExpression.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/CustomFuntionExpression.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -107,6 +108,8 @@ public abstract class CustomFuntionExpression<T> implements Expression<T> {
     private Expression<?> convertExpression(Object value) {
         if(value instanceof Expression) {
             return (Expression)value;
+        } else if(value instanceof Collection) {
+            return Constant.createCollection((Collection)value);
         } else {
             return Constant.create(value);
         }

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/CustomFuntionExpression.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/CustomFuntionExpression.java
@@ -1,0 +1,205 @@
+package com.github.mygreen.sqlmapper.metamodel.expression;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.github.mygreen.sqlmapper.metamodel.operation.BooleanOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.EnumOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.LocalDateOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.LocalDateTimeOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.LocalTimeOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.NumberOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.SqlDateOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.SqlTimeOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.SqlTimestampOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.StringOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.UtilDateOperation;
+import com.github.mygreen.sqlmapper.metamodel.operator.FunctionOp;
+
+import lombok.Getter;
+
+
+/**
+ * 任意の関数式を表現します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public abstract class CustomFuntionExpression<T> implements Expression<T> {
+
+    protected final Expression<?> mixin;
+
+    /**
+     * 関数のクエリ
+     */
+    @Getter
+    protected final String query;
+
+    /**
+     * 関数の引数
+     */
+    @Getter
+    protected final List<Expression<?>> args;
+
+    public CustomFuntionExpression(Expression<?> mixin, String query, Object... args) {
+        if(query == null || query.isEmpty()) {
+            throw new IllegalArgumentException("query should be not empty.");
+        }
+
+        /*
+         * クエリ中のプレースホルダーと引数の個数を比較する。
+         * プレースホルダーをカウントするときには、文字列句('abc')などを考慮する必要があるが、
+         * そこまで複雑なことはしないと思うので実施しない。
+         */
+        int countPlaceHolder = countPlaceHolder(query);
+        int sizeArgs = (args == null ? 0 : args.length);
+        if(countPlaceHolder != sizeArgs) {
+            throw new IllegalArgumentException(String.format("'%s' is not match place holder count '%d'. ", query, countPlaceHolder));
+        }
+
+        this.mixin = mixin;
+        this.query = query;
+        if(sizeArgs == 0) {
+            this.args = Collections.emptyList();
+        } else {
+            this.args = Arrays.stream(args)
+                    .map(this::convertExpression)
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+    /**
+     * 文字列中のプレースホルダーの出現回数をカウントします。
+     * @param text
+     * @return 出現回数
+     */
+    private int countPlaceHolder(final String text) {
+
+        int count = 0;
+        int length = text.length();
+
+        for(int i=0; i < length; i++) {
+            char c = text.charAt(i);
+            if(c == '?') {
+                count++;
+            }
+        }
+
+        return count;
+
+    }
+
+    /**
+     * 値を式オブジェクトに変換する。
+     * @param value 値
+     * @return 変換した値
+     */
+    @SuppressWarnings("rawtypes")
+    private Expression<?> convertExpression(Object value) {
+        if(value instanceof Expression) {
+            return (Expression)value;
+        } else {
+            return Constant.create(value);
+        }
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return ブーリアン型を返します。
+     */
+    public BooleanExpression returnBoolean() {
+        return new BooleanOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return 文字列型を返します。
+     */
+    public StringExpression returnString() {
+        return new StringOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @param type 数値の具象クラスを指定します。
+     * @return 数値型を返します。
+     */
+    public <R extends Number & Comparable<R>> NumberExpression<R> returnNumber(Class<R> type) {
+        return new NumberOperation<R>(type, FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return {@link LocalDate}型を返します。
+     */
+    public LocalDateExpression returnLocalDate() {
+        return new LocalDateOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return {@link LocalTime}型を返します。
+     */
+    public LocalTimeExpression returnLocalTime() {
+        return new LocalTimeOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return {@link LocalDateTime}型を返します。
+     */
+    public LocalDateTimeExpression returnLocalDateTime() {
+        return new LocalDateTimeOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return {@link Date}型を返します。
+     */
+    public SqlDateExpression returnSqlDate() {
+        return new SqlDateOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return {@link Time}型を返します。
+     */
+    public SqlTimeExpression returnSqlTime() {
+        return new SqlTimeOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return {@link Timestamp}型を返します。
+     */
+    public SqlTimestampExpression returnSqlTimeStamp() {
+        return new SqlTimestampOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return {@link java.util.Date}型を返します。
+     */
+    public UtilDateExpression returnUtilDate() {
+        return new UtilDateOperation(FunctionOp.CUSTOM, mixin, this);
+    }
+
+    /**
+     * 関数の戻り値の型を返します。
+     * @return 列挙型を返します。
+     */
+    public <R extends Enum<R>> EnumExpression<R> returnEnum(Class<R> type) {
+        return new EnumOperation<R>(type, FunctionOp.CUSTOM, mixin, this);
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/GeneralExpression.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/GeneralExpression.java
@@ -13,7 +13,7 @@ import com.github.mygreen.sqlmapper.metamodel.operator.UnaryOp;
  * 汎用的な型に対する式。
  * <p>{@literal byte[]} 型など専用の式の型がないときに用います。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  * @param <T> 式のタイプ
  *
@@ -171,6 +171,8 @@ public abstract class GeneralExpression<T> extends DslExpression<T> {
      * </ul>
      *
      * <p>例：{@literal sample_func($this, ?, ?)}
+     *
+     * @since 0.3
      * @param query 関数の書式。
      * @param args 関数に渡すバインド変数を指定します。定数、{@literal Expression} を指定します。
      * @return 関数式。

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/GeneralExpression.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/GeneralExpression.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import com.github.mygreen.sqlmapper.metamodel.operation.BooleanOperation;
+import com.github.mygreen.sqlmapper.metamodel.operation.CustomFunctionOperation;
 import com.github.mygreen.sqlmapper.metamodel.operator.ComparisionOp;
 import com.github.mygreen.sqlmapper.metamodel.operator.UnaryOp;
 
@@ -157,6 +158,26 @@ public abstract class GeneralExpression<T> extends DslExpression<T> {
      */
     public BooleanExpression notIn(SubQueryExpression<T> right) {
         return new BooleanOperation(ComparisionOp.NOT_IN, mixin, right);
+    }
+
+    /**
+     * 任意の関数の式を作成します。
+     * <p>関数中には変数が使用できます。
+     * <ul>
+     *  <li>{@literal $this} : この関数を適用する式。クエリ実行時には展開されます。</li>
+     *  <li>{@literal ?} : プレースホルダー。クエリ実行時に展開されます。
+     *   <br />引数{@literal args} の個数と一致させる必要があります。
+     *  </li>
+     * </ul>
+     *
+     * <p>例：{@literal sample_func($this, ?, ?)}
+     * @param query 関数の書式。
+     * @param args 関数に渡すバインド変数を指定します。定数、{@literal Expression} を指定します。
+     * @return
+     */
+    @SuppressWarnings("rawtypes")
+    public CustomFuntionExpression function(String query, Object... args) {
+        return new CustomFunctionOperation(mixin, query, args);
     }
 
  }

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/GeneralExpression.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/GeneralExpression.java
@@ -173,7 +173,7 @@ public abstract class GeneralExpression<T> extends DslExpression<T> {
      * <p>例：{@literal sample_func($this, ?, ?)}
      * @param query 関数の書式。
      * @param args 関数に渡すバインド変数を指定します。定数、{@literal Expression} を指定します。
-     * @return
+     * @return 関数式。
      */
     @SuppressWarnings("rawtypes")
     public CustomFuntionExpression function(String query, Object... args) {

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/operation/CustomFunctionOperation.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/operation/CustomFunctionOperation.java
@@ -1,0 +1,57 @@
+package com.github.mygreen.sqlmapper.metamodel.operation;
+
+import java.util.Optional;
+
+import com.github.mygreen.sqlmapper.metamodel.Visitor;
+import com.github.mygreen.sqlmapper.metamodel.expression.CustomFuntionExpression;
+import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
+import com.github.mygreen.sqlmapper.metamodel.operator.FunctionOp;
+import com.github.mygreen.sqlmapper.metamodel.operator.Operator;
+
+
+/**
+ * {@link CustomFuntionExpression}の実装クラスです。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+@SuppressWarnings("rawtypes")
+public class CustomFunctionOperation extends CustomFuntionExpression implements Operation {
+
+    @SuppressWarnings("unchecked")
+    public CustomFunctionOperation(Expression<?> mixin, String query, Object... args) {
+        super(mixin, query, args);
+    }
+
+    @Override
+    public Class<?> getType() {
+        return Object.class;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void accept(Visitor visitor, Object context) {
+        visitor.visit(this, context);
+    }
+
+    @Override
+    public Operator getOperator() {
+        return FunctionOp.CUSTOM;
+    }
+
+    @Override
+    public Expression<?> getArg(int index) {
+        return (Expression)args.get(index);
+    }
+
+    @Override
+    public Optional<Expression<?>> getOptArg(int index) {
+        if(index >= args.size()) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable((Expression)args.get(index));
+        }
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/operator/FunctionOp.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/operator/FunctionOp.java
@@ -18,7 +18,10 @@ public enum FunctionOp implements Operator {
     // Date/Time
     CURRENT_DATE(Comparable.class, -1),
     CURRENT_TIME(Comparable.class, -1),
-    CURRENT_TIMESTAMP(Comparable.class, -1)
+    CURRENT_TIMESTAMP(Comparable.class, -1),
+
+    // 任意の関数
+    CUSTOM(Object.class, -1);
 
     ;
 


### PR DESCRIPTION
- 任意の関数を指定できるメソッド ``function(...)`` をメタモデルに追加。
  - GeneralExpression に追加しているため、どこからも使用可能。


- メタモデルでの指定の方法
```java
MCustomer entity = MCustomer.customer;
Predicate condition = entity.firstName.function("custom_format($this, 'yyyMMdd')").returnString()
         .function("custom_is_valid($this, ?)", "TEST").returnBoolean();
```

- 実行されるSQL
```sql
custom_is_valid(custom_format(T1_.FIRST_NAME, 'yyyMMdd'), ?)
```