### PR TITLE
デバッグ用のVisitorに任意のSQL関数を対応

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/where/metamodel/MetamodelWhereBuilderTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/where/metamodel/MetamodelWhereBuilderTest.java
@@ -209,8 +209,8 @@ public class MetamodelWhereBuilderTest {
     @Test
     void testCustomFunction() {
         MCustomer entity = MCustomer.customer;
-        Predicate condition = entity.firstName.function("custom_format($this, 'yyyMMdd')").returnString()
-                .function("custom_is_valid($this, ?)", "TEST").returnBoolean();
+        Predicate condition = entity.firstName.function("custom_format($left, 'yyyMMdd')").returnString()
+                .function("custom_is_valid($left, ?)", "TEST").returnBoolean();
 
         EntityMeta entityMeta = entityMetaFactory.create(Customer.class);
 

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/GeneralExpression.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/GeneralExpression.java
@@ -164,13 +164,13 @@ public abstract class GeneralExpression<T> extends DslExpression<T> {
      * 任意の関数の式を作成します。
      * <p>関数中には変数が使用できます。
      * <ul>
-     *  <li>{@literal $this} : この関数を適用する式。クエリ実行時には展開されます。</li>
+     *  <li>{@literal $left} : 左辺。クエリ実行時には展開されます。</li>
      *  <li>{@literal ?} : プレースホルダー。クエリ実行時に展開されます。
      *   <br />引数{@literal args} の個数と一致させる必要があります。
      *  </li>
      * </ul>
      *
-     * <p>例：{@literal sample_func($this, ?, ?)}
+     * <p>例：{@literal sample_func($left, ?, ?)}
      *
      * @since 0.3
      * @param query 関数の書式。

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/SqlFunctionParser.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/SqlFunctionParser.java
@@ -1,0 +1,74 @@
+package com.github.mygreen.sqlmapper.metamodel.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.mygreen.sqlmapper.metamodel.support.SqlFunctionTokenizer.TokenType;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * SQL関数の書式のパーサー
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class SqlFunctionParser {
+
+    /**
+     * 字句解析してトークンに分解した結果
+     *
+     */
+    @AllArgsConstructor
+    public static class Token {
+
+        /**
+         * トークンのタイプ
+         */
+        public final TokenType type;
+
+        /**
+         * トークンの値。
+         */
+        public final String value;
+
+        /**
+         * バインド変数の場合のインデックス。
+         * <p>バインド変数でないときは、値は{@literal -1}です。
+         */
+        public final int bindBariableIndex;
+
+    }
+
+    /**
+     * SQL関数をパースしてトークンに分解します。
+     * @param sql パース対象のSQL
+     * @return トークンに分解した結果。
+     * @throws IllegalArgumentException 不明なトークンタイプの場合にスローされます。
+     */
+    public List<Token> parse(final String sql) {
+
+        SqlFunctionTokenizer tokenizer = new SqlFunctionTokenizer(sql);
+
+        List<Token> tokens = new ArrayList<>();
+        while(TokenType.EOF != tokenizer.next()) {
+            TokenType currentToken = tokenizer.getTokenType();
+            if(currentToken == TokenType.SQL) {
+                tokens.add(new Token(currentToken, tokenizer.getToken(), -1));
+
+            } else if(currentToken == TokenType.LEFT_VARIABLE) {
+                tokens.add(new Token(currentToken, tokenizer.getToken(), -1));
+
+            } else if(currentToken == TokenType.BIND_VARIABLE) {
+                int varIndex = tokenizer.getBindBariableNum() - 1;
+                tokens.add(new Token(currentToken, tokenizer.getToken(), varIndex));
+
+            } else {
+                throw new IllegalArgumentException("unknown token type : " + currentToken);
+            }
+        }
+
+        return tokens;
+    }
+}

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/SqlFunctionTokenizer.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/SqlFunctionTokenizer.java
@@ -1,4 +1,4 @@
-package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+package com.github.mygreen.sqlmapper.metamodel.support;
 
 /**
  * SQL関数の字句解析処理。
@@ -15,7 +15,7 @@ public class SqlFunctionTokenizer {
      */
     public enum TokenType {
         SQL,
-        THIS_VARIABLE,
+        LEFT_VARIABLE,
         BIND_VARIABLE,
         EOF
     }
@@ -118,8 +118,8 @@ public class SqlFunctionTokenizer {
         case SQL:
             parseSql();
             break;
-        case THIS_VARIABLE:
-            parseThisVariable();
+        case LEFT_VARIABLE:
+            parseLeftVariable();
             break;
         case BIND_VARIABLE:
             parseBindVariable();
@@ -136,9 +136,9 @@ public class SqlFunctionTokenizer {
      */
     protected void parseSql() {
 
-        int thisVariableStartPos = sql.indexOf("$this", position);
+        int leftVariableStartPos = sql.indexOf("$left", position);
         int bindVariableStartPos = sql.indexOf("?", position);
-        int nextStartPos = getNextStartPos(thisVariableStartPos, bindVariableStartPos);
+        int nextStartPos = getNextStartPos(leftVariableStartPos, bindVariableStartPos);
 
         if (nextStartPos < 0) {
             // 特定のトークンでない場合は、すべてSQL区分する。
@@ -152,9 +152,9 @@ public class SqlFunctionTokenizer {
             tokenType = TokenType.SQL;
             boolean needNext = nextStartPos == position;
 
-            if (nextStartPos == thisVariableStartPos) {
-                nextTokenType = TokenType.THIS_VARIABLE;
-                position = thisVariableStartPos + 4;
+            if (nextStartPos == leftVariableStartPos) {
+                nextTokenType = TokenType.LEFT_VARIABLE;
+                position = leftVariableStartPos + 4;
 
             } else if (nextStartPos == bindVariableStartPos) {
                 nextTokenType = TokenType.BIND_VARIABLE;
@@ -170,15 +170,15 @@ public class SqlFunctionTokenizer {
     /**
      * 次のトークンの開始位置を返します。
      *
-     * @param thisVariableStartPos {@literal $this} 変数の開始位置
+     * @param leftVariableStartPos {@literal $left} 変数の開始位置
      * @param bindVariableStartPos {@literal ?} 変数の開始位置
      * @return 次のトークンの開始位置。特定のトークンでない場合は {@literal -1} を返します。
      */
-    protected int getNextStartPos(int thisVariableStartPos, int bindVariableStartPos) {
+    protected int getNextStartPos(int leftVariableStartPos, int bindVariableStartPos) {
 
         int nextStartPos = -1;
-        if (thisVariableStartPos >= 0) {
-            nextStartPos = thisVariableStartPos;
+        if (leftVariableStartPos >= 0) {
+            nextStartPos = leftVariableStartPos;
         }
 
         if (bindVariableStartPos >= 0
@@ -189,13 +189,13 @@ public class SqlFunctionTokenizer {
     }
 
     /**
-     * {@literal $this} 変数をパースします。
+     * {@literal $left} 変数をパースします。
      */
-    protected void parseThisVariable() {
-        token = "$this";
+    protected void parseLeftVariable() {
+        token = "$left";
         nextTokenType = TokenType.SQL;
         position += 1;
-        tokenType = TokenType.THIS_VARIABLE;
+        tokenType = TokenType.LEFT_VARIABLE;
     }
 
     /**

--- a/sqlmapper-parent/sqlmapper-metamodel/src/test/java/com/github/mygreen/sqlmapper/metamodel/EmbeddedPathTest.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/test/java/com/github/mygreen/sqlmapper/metamodel/EmbeddedPathTest.java
@@ -56,7 +56,7 @@ public class EmbeddedPathTest {
                 .and(entity.name.contains("Taro"));
         String resultString = exp.toString();
 
-        assertThat(resultString).isEqualTo("sampleEntity.id.key1 = 100 and contains(sampleEntity.name, Taro)");
+        assertThat(resultString).isEqualTo("sampleEntity.id.key1 = '100' and contains(sampleEntity.name, 'Taro')");
 
     }
 

--- a/sqlmapper-parent/sqlmapper-metamodel/src/test/java/com/github/mygreen/sqlmapper/metamodel/NormalPathTest.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/test/java/com/github/mygreen/sqlmapper/metamodel/NormalPathTest.java
@@ -60,7 +60,7 @@ public class NormalPathTest {
                 ;
 
         String resultString = exp.toString();
-        assertThat(resultString).isEqualTo("contains(lower(sampleEntity.name), yamada) and (sampleEntity.age + 10) > 20 and sampleEntity.role in [Admin, Normal] and sampleEntity.updateAt > current_timestamp and sampleEntity.deleted = false and sampleEntity.salary >= 1000000");
+        assertThat(resultString).isEqualTo("contains(lower(sampleEntity.name), 'yamada') and (sampleEntity.age + 10) > 20 and sampleEntity.role in [Admin, Normal] and sampleEntity.updateAt > current_timestamp and sampleEntity.deleted = false and sampleEntity.salary >= 1000000");
 
     }
 
@@ -74,6 +74,18 @@ public class NormalPathTest {
                 .collect(Collectors.joining(", "));
 
         assertThat(resultString).isEqualTo("sampleEntity.name DESC, sampleEntity.role ASC");
+
+    }
+
+    @Test
+    void testCustomFunction() {
+        MSampleEntity entity = MSampleEntity.sampleEntity;
+
+        Predicate exp = entity.name.function("custom_format($left, 'yyyMMdd')").returnString()
+                .function("custom_is_valid($left, ?)", "TEST").returnBoolean();
+
+        String resultString = exp.toString();
+        assertThat(resultString).isEqualTo("custom_is_valid(custom_format(sampleEntity.name, 'yyyMMdd'), 'TEST')");
 
     }
 

--- a/sqlmapper-parent/sqlmapper-metamodel/src/test/java/com/github/mygreen/sqlmapper/metamodel/support/SqlFunctionTokenizerTest.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/test/java/com/github/mygreen/sqlmapper/metamodel/support/SqlFunctionTokenizerTest.java
@@ -1,17 +1,17 @@
-package com.github.mygreen.sqlmapper.core.where.metamodel.function;
+package com.github.mygreen.sqlmapper.metamodel.support;
 
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.mygreen.sqlmapper.core.where.metamodel.function.SqlFunctionTokenizer.TokenType;
+import com.github.mygreen.sqlmapper.metamodel.support.SqlFunctionTokenizer.TokenType;
 
 
 public class SqlFunctionTokenizerTest {
 
     @Test
     void testParse() {
-        SqlFunctionTokenizer tokenizer = new SqlFunctionTokenizer("custom_test($this, ?)");
+        SqlFunctionTokenizer tokenizer = new SqlFunctionTokenizer("custom_test($left, ?)");
 
         {
             TokenType type = tokenizer.next();
@@ -22,9 +22,9 @@ public class SqlFunctionTokenizerTest {
 
         {
             TokenType type = tokenizer.next();
-            assertThat(type).isEqualTo(TokenType.THIS_VARIABLE);
+            assertThat(type).isEqualTo(TokenType.LEFT_VARIABLE);
             String sql = tokenizer.getToken();
-            assertThat(sql).isEqualTo("$this");
+            assertThat(sql).isEqualTo("$left");
         }
 
         {


### PR DESCRIPTION
- SQL関数のパーサー `SqlFunctionParser` を追加し、パースした結果をあらかじめキャッシュしておくように修正。
- 条件式のデバッグ用の処理にて、任意のSQL関数を処理できるよう修正。
- 任意のSQL関数中の変数 `$this` -> `$left` に変更。