### PR TITLE
LIMIT句のoffsetが-1のときlimit句が設定されない事象を修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/Dialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/Dialect.java
@@ -82,6 +82,7 @@ public interface Dialect {
      * @param offset オフセット。省略する場合は {@literal -1}を指定します。
      * @param limit リミット。省略する場合は {@literal -1} を指定します。
      * @return LIMIT用SQL。
+     * @throws IllegalArgumentException 引数{@literal offset} と {@literal limit} の値の両方が 0より小さい場合にスローされます。
      */
     String convertLimitSql(String sql, int offset, int limit);
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/DialectBase.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/DialectBase.java
@@ -84,19 +84,26 @@ public abstract class DialectBase implements Dialect {
         return " for update";
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String convertLimitSql(String sql, int offset, int limit) {
 
+        if(offset < 0 && limit < 0) {
+            throw new IllegalArgumentException("Either offset or limit should be greather than 0.");
+        }
+
         StringBuilder buf = new StringBuilder(sql.length() + 20);
         buf.append(sql);
-        if (offset > 0) {
-            buf.append(" limit ")
-                .append(limit)
-                .append(" offset ")
-                .append(offset);
-        } else {
+        if (limit >= 0) {
             buf.append(" limit ")
                 .append(limit);
+        }
+
+        if (offset >= 0) {
+            buf.append(" offset ")
+                .append(offset);
         }
 
         return buf.toString();

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/OracleDialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/OracleDialect.java
@@ -113,19 +113,26 @@ public class OracleDialect extends DialectBase {
      * {@inheritDoc}
      *
      * @return {@literal OFFSET/FETCH} を使用して、LIMIT句を組み立てます。
+     * @throws IllegalArgumentException 引数{@literal offset} または {@literal limit} の値の何れかが 0より小さい場合にスローされます。
      */
     @Override
     public String convertLimitSql(String sql, int offset, int limit) {
 
+        if(offset < 0 && limit < 0) {
+            throw new IllegalArgumentException("Either offset or limit should be greather than 0.");
+        }
+
         StringBuilder buf = new StringBuilder(sql.length() + 20);
         buf.append(sql);
-        if (offset > 0) {
+
+        if(offset >= 0) {
             buf.append(" offset ")
                 .append(offset)
-                .append(" fetch first ")
-                .append(limit)
-                .append(" rows only");
-        } else {
+                .append(" rows");
+
+        }
+
+        if(limit >= 0) {
             buf.append(" fetch first ")
                 .append(limit)
                 .append(" rows only");

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/H2DialectTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/H2DialectTest.java
@@ -1,0 +1,44 @@
+package com.github.mygreen.sqlmapper.core.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+
+
+public class H2DialectTest extends H2Dialect {
+
+    @Test
+    void testGetName() {
+        assertThat(getName()).isEqualTo("h2");
+    }
+
+    @Test
+    void testSupportsGenerationType() {
+        assertThat(supportsGenerationType(GenerationType.IDENTITY)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.SEQUENCE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.TABLE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.UUID)).isTrue();
+    }
+
+    @Test
+    void testGetSequenceIncrementer() {
+        assertThat(getSequenceIncrementer(new SimpleDriverDataSource(), "test")).isNotNull();
+    }
+
+    @Test
+    void testConvertLimitSql() {
+        String select = "select * from sample";
+        assertThatThrownBy(() -> convertLimitSql(select, -1, -1)).isInstanceOf(IllegalArgumentException.class);
+        assertThat(convertLimitSql(select, -1, 5)).isEqualTo("select * from sample limit 5");
+        assertThat(convertLimitSql(select, 10, -1)).isEqualTo("select * from sample offset 10");
+        assertThat(convertLimitSql(select, 10, 5)).isEqualTo("select * from sample limit 5 offset 10");
+    }
+
+    @Test
+    void testNeedsParameterForResultSet() {
+        assertThat(needsParameterForResultSet()).isFalse();
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/HsqlDialectTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/HsqlDialectTest.java
@@ -1,0 +1,30 @@
+package com.github.mygreen.sqlmapper.core.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+
+
+public class HsqlDialectTest extends HsqlDialect {
+
+    @Test
+    void testGetName() {
+        assertThat(getName()).isEqualTo("hsql");
+    }
+
+    @Test
+    void testSupportsGenerationType() {
+        assertThat(supportsGenerationType(GenerationType.IDENTITY)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.SEQUENCE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.TABLE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.UUID)).isTrue();
+    }
+
+    @Test
+    void testGetSequenceIncrementer() {
+        assertThat(getSequenceIncrementer(new SimpleDriverDataSource(), "test")).isNotNull();
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/OracleDialectTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/OracleDialectTest.java
@@ -1,0 +1,65 @@
+package com.github.mygreen.sqlmapper.core.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+import com.github.mygreen.sqlmapper.core.query.SelectForUpdateType;
+
+
+public class OracleDialectTest extends OracleDialect {
+
+    @Test
+    void testGetName() {
+        assertThat(getName()).isEqualTo("oracle");
+    }
+
+    @Test
+    void testSupportsGenerationType() {
+        assertThat(supportsGenerationType(GenerationType.IDENTITY)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.SEQUENCE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.TABLE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.UUID)).isTrue();
+    }
+
+    @Test
+    void testGetSequenceIncrementer() {
+        assertThat(getSequenceIncrementer(new SimpleDriverDataSource(), "test")).isNotNull();
+    }
+
+    @Test
+    void testGetHintComment() {
+        assertThat(getHintComment("TEST")).isEqualTo("/*+ TEST */ ");
+    }
+
+    @Test
+    void testSupportsSelectForUpdate() {
+        assertThat(supportsSelectForUpdate(SelectForUpdateType.NORMAL)).isTrue();
+        assertThat(supportsSelectForUpdate(SelectForUpdateType.NOWAIT)).isTrue();
+        assertThat(supportsSelectForUpdate(SelectForUpdateType.WAIT)).isTrue();
+    }
+
+    @Test
+    void testGetForUpdateSql() {
+        assertThat(getForUpdateSql(SelectForUpdateType.NORMAL, 10)).isEqualTo(" for update");
+        assertThat(getForUpdateSql(SelectForUpdateType.NOWAIT, 10)).isEqualTo(" for update nowait");
+        assertThat(getForUpdateSql(SelectForUpdateType.WAIT, 10)).isEqualTo(" for update wait 10");
+    }
+
+    @Test
+    void testConvertLimitSql() {
+        String select = "select * from sample";
+        assertThatThrownBy(() -> convertLimitSql(select, -1, -1)).isInstanceOf(IllegalArgumentException.class);
+        assertThat(convertLimitSql(select, -1, 5)).isEqualTo("select * from sample fetch first 5 rows only");
+        assertThat(convertLimitSql(select, 10, -1)).isEqualTo("select * from sample offset 10 rows");
+        assertThat(convertLimitSql(select, 10, 5)).isEqualTo("select * from sample offset 10 rows fetch first 5 rows only");
+    }
+
+    @Test
+    void testNeedsParameterForResultSet() {
+        assertThat(needsParameterForResultSet()).isTrue();
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/OracleLegacyDialectTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/OracleLegacyDialectTest.java
@@ -1,0 +1,34 @@
+package com.github.mygreen.sqlmapper.core.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+
+
+public class OracleLegacyDialectTest extends OracleLegacyDialect {
+
+    @Test
+    void testGetName() {
+        assertThat(getName()).isEqualTo("oracle");
+    }
+
+    @Test
+    void testSupportsGenerationType() {
+        assertThat(supportsGenerationType(GenerationType.IDENTITY)).isFalse();
+        assertThat(supportsGenerationType(GenerationType.SEQUENCE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.TABLE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.UUID)).isTrue();
+    }
+
+    @Test
+    void testConvertLimitSql() {
+        String select = "select * from sample";
+        assertThatThrownBy(() -> convertLimitSql(select, -1, -1)).isInstanceOf(IllegalArgumentException.class);
+        assertThat(convertLimitSql(select, -1, 5)).isEqualTo("select * from ( select temp_.*, rownum rownumber_ from ( select * from sample ) temp_ ) where rownumber_ <= 5");
+        assertThat(convertLimitSql(select, 10, -1)).isEqualTo("select * from ( select temp_.*, rownum rownumber_ from ( select * from sample ) temp_ ) where rownumber_ >= 11");
+        assertThat(convertLimitSql(select, 10, 5)).isEqualTo("select * from ( select temp_.*, rownum rownumber_ from ( select * from sample ) temp_ ) where rownumber_ between 11 and 15");
+
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/PostgresDialectTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/PostgresDialectTest.java
@@ -1,0 +1,36 @@
+package com.github.mygreen.sqlmapper.core.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+
+
+public class PostgresDialectTest extends PostgresDialect {
+
+    @Test
+    void testGetName() {
+        assertThat(getName()).isEqualTo("pgsql");
+    }
+
+    @Test
+    void testSupportsGenerationType() {
+        assertThat(supportsGenerationType(GenerationType.IDENTITY)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.SEQUENCE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.TABLE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.UUID)).isTrue();
+    }
+
+    @Test
+    void testGetSequenceIncrementer() {
+        assertThat(getSequenceIncrementer(new SimpleDriverDataSource(), "test")).isNotNull();
+    }
+
+    @Test
+    void testNeedsParameterForResultSet() {
+        assertThat(needsParameterForResultSet()).isTrue();
+    }
+
+}

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/SqliteDialectTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/dialect/SqliteDialectTest.java
@@ -1,0 +1,30 @@
+package com.github.mygreen.sqlmapper.core.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+
+
+public class SqliteDialectTest extends SqliteDialect {
+
+    @Test
+    void testGetName() {
+        assertThat(getName()).isEqualTo("sqlite");
+    }
+
+    @Test
+    void testSupportsGenerationType() {
+        assertThat(supportsGenerationType(GenerationType.IDENTITY)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.SEQUENCE)).isFalse();
+        assertThat(supportsGenerationType(GenerationType.TABLE)).isTrue();
+        assertThat(supportsGenerationType(GenerationType.UUID)).isTrue();
+    }
+
+    @Test
+    void testGetSequenceIncrementer() {
+        assertThat(getSequenceIncrementer(new SimpleDriverDataSource(), "test")).isNull();
+    }
+}


### PR DESCRIPTION
- LIMIT/OFFSET句の判定をそれぞれに分離し、offsetが指定なし（-1）のときも、LIMIT句が設定されるよう修正。
- Dialectのテスタを追加。