### PR TITLE
in句の値が評価時に展開されない事象を修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ExpressionVisitor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ExpressionVisitor.java
@@ -88,7 +88,7 @@ public class ExpressionVisitor implements Visitor<VisitorContext> {
             Collection<?> values = (Collection<?>)expr.getValue();
             context.addParamValues(values);
             context.appendSql("(")
-                .append(QueryUtils.repeat("?", ",", values.size()))
+                .append(QueryUtils.repeat("?", ", ", values.size()))
                 .append(")");
         } else {
             context.addParamValue(expr.getValue());

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/Constant.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/expression/Constant.java
@@ -35,7 +35,7 @@ public class Constant<T> extends ImmutableExpression<T> {
     public Constant(final Class<? extends T> type, final T value, boolean expandable) {
         super(type);
         this.value = value;
-        this.expandable = false;
+        this.expandable = expandable;
     }
 
     /**

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/DebugVisitor.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/DebugVisitor.java
@@ -182,14 +182,16 @@ public class DebugVisitor implements Visitor<DebugVisitorContext>{
             context.append("null");
 
         } else if(expr.isExpandable()) {
+            context.append("(");
             StringBuilder joined = new StringBuilder();
             for(Object value : (Collection<?>)constant) {
                 if(joined.length() > 0) {
-                    joined.append(",");
+                    joined.append(", ");
                 }
                 joined.append(formatConstantValue(value));
             }
-            context.append(joined.toString());
+            context.append(joined.toString())
+                .append(")");
 
         } else {
             context.append(formatConstantValue(constant));

--- a/sqlmapper-parent/sqlmapper-metamodel/src/test/java/com/github/mygreen/sqlmapper/metamodel/NormalPathTest.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/test/java/com/github/mygreen/sqlmapper/metamodel/NormalPathTest.java
@@ -60,7 +60,7 @@ public class NormalPathTest {
                 ;
 
         String resultString = exp.toString();
-        assertThat(resultString).isEqualTo("contains(lower(sampleEntity.name), 'yamada') and (sampleEntity.age + 10) > 20 and sampleEntity.role in [Admin, Normal] and sampleEntity.updateAt > current_timestamp and sampleEntity.deleted = false and sampleEntity.salary >= 1000000");
+        assertThat(resultString).isEqualTo("contains(lower(sampleEntity.name), 'yamada') and (sampleEntity.age + 10) > 20 and sampleEntity.role in (Admin, Normal) and sampleEntity.updateAt > current_timestamp and sampleEntity.deleted = false and sampleEntity.salary >= 1000000");
 
     }
 


### PR DESCRIPTION
- in句で、Collecitionなどの複数要素を引数で渡したときに、SQL実行時に展開されない事象を修正。
- フラグ `expandable` がfalse固定となっていたのを修正。