### PR TITLE
mod演算子をクエリ実行時には関数で実行するよう変更

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ArithmeticOpHandler.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ArithmeticOpHandler.java
@@ -21,7 +21,7 @@ public class ArithmeticOpHandler extends OperationHandler<ArithmeticOp> {
         // 算術演算子
         addTemplate(ArithmeticOp.MULT, "{0} * {1}");
         addTemplate(ArithmeticOp.DIV, "{0} / {1}");
-        addTemplate(ArithmeticOp.MOD, "{0} % {1}");
+        addTemplate(ArithmeticOp.MOD, "mod({0}, {1})");
         addTemplate(ArithmeticOp.ADD, "{0} + {1}");
         addTemplate(ArithmeticOp.SUB, "{0} - {1}");
 

--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/DebugVisitor.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/DebugVisitor.java
@@ -86,7 +86,7 @@ public class DebugVisitor implements Visitor<DebugVisitorContext>{
         // ArithmeticOp
         operationTemplateMap.put(ArithmeticOp.MULT, "{0} * {1}");
         operationTemplateMap.put(ArithmeticOp.DIV, "{0} / {1}");
-        operationTemplateMap.put(ArithmeticOp.MOD, "{0} % {1}");
+        operationTemplateMap.put(ArithmeticOp.MOD, "mod({0}, {1})");
         operationTemplateMap.put(ArithmeticOp.ADD, "{0} + {1}");
         operationTemplateMap.put(ArithmeticOp.SUB, "{0} - {1}");
 


### PR DESCRIPTION
- mod 演算子( `%` ) をサポートしているDBは少ないので、関数に変更。