### PR TITLE
親と子が同じ演算子グループのときの括弧で囲むように変更

### DIFF
--- a/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/OperationUtils.java
+++ b/sqlmapper-parent/sqlmapper-metamodel/src/main/java/com/github/mygreen/sqlmapper/metamodel/support/OperationUtils.java
@@ -34,6 +34,9 @@ public class OperationUtils {
             // 親ノードがOR/ANDで子ノードがBETWEENのとき
             // 実際は括弧で囲まなくてもよいが見やすさのために囲む
             return true;
+        } else if(parentOp.getClass().equals(childOp.getClass())) {
+            // 親ノードと子ノードが同じ演算子グループの場合、それぞれの優先度に従う
+            return parentOp.getPriority() < childOp.getPriority();
         } else if(childOp instanceof ArithmeticOp) {
             // 子ノードが算術演算子の場合、必ず囲む。
             return true;


### PR DESCRIPTION
- クエリの条件式を評価するさいに、親ノードと子ノードが同じ演算子グループのとき、強制的にカッコで囲むよう修正。
- SQL実行時の見やすさを優先する。

```sql
(a + b) + (a -b)
```