### PR TITLE
offsetの値が0のときスキップされる事象を修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/Dialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/Dialect.java
@@ -77,12 +77,12 @@ public interface Dialect {
     String getHintComment(String hint);
 
     /**
-     * LIMIT用SQLに変換します。
+     * LIMIT句用SQLに変換します。
      * @param sql SQL
      * @param offset オフセット。省略する場合は {@literal -1}を指定します。
      * @param limit リミット。省略する場合は {@literal -1} を指定します。
-     * @return LIMIT用SQL。
-     * @throws IllegalArgumentException 引数{@literal offset} と {@literal limit} の値の両方が 0より小さい場合にスローされます。
+     * @return LIMIT句用SQL。
+     * @throws IllegalArgumentException 引数{@literal offset} と {@literal limit} の値の両方が0より小さい場合にスローされます。
      */
     String convertLimitSql(String sql, int offset, int limit);
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelect.java
@@ -77,7 +77,7 @@ public interface AutoSelect<T> {
 
     /**
      * 抽出するデータの開始位置を指定します。
-     * @param offset 開始位置。
+     * @param offset 開始位置。0から始まります。
      * @return このインスタンス自身
      */
     AutoSelect<T> offset(int offset);

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelectExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelectExecutor.java
@@ -470,7 +470,7 @@ public class AutoSelectExecutor<T> {
         }
 
         // LIMIT句を指定していないかのチェック
-        if(query.getLimit() > 0 || query.getOffset() > 0) {
+        if(query.getLimit() > 0 || query.getOffset() >= 0) {
             throw new IllegalOperateException(context.getMessageFormatter().create("query.notSupportPaginationWithForUpdate")
                     .format());
         }
@@ -502,7 +502,7 @@ public class AutoSelectExecutor<T> {
                 + orderByClause.toSql()
                 + forUpdateClause;
 
-        if(query.getLimit() > 0 || query.getLimit() == 0 && query.getOffset() > 0) {
+        if(query.getLimit() > 0 || query.getOffset() >= 0) {
             sql = dialect.convertLimitSql(sql, query.getOffset(), query.getLimit());
         }
 


### PR DESCRIPTION
- offsetは0から始まるため、無視しないよう判定条件を修正。