### PR TITLE
条件式を組み立てる際のプロパティに対する定数を指定したときにValueTypeによる変換がされない事象を修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ArithmeticOpHandler.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ArithmeticOpHandler.java
@@ -1,6 +1,6 @@
 package com.github.mygreen.sqlmapper.core.where.metamodel;
 
-import com.github.mygreen.sqlmapper.metamodel.PropertyPath;
+import com.github.mygreen.sqlmapper.metamodel.Path;
 import com.github.mygreen.sqlmapper.metamodel.Visitor;
 import com.github.mygreen.sqlmapper.metamodel.expression.Constant;
 import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
@@ -43,8 +43,8 @@ public class ArithmeticOpHandler extends OperationHandler<ArithmeticOp> {
          * 算術演算子の場合、左変=プロパティパス、右辺=定数で構成される場合、
          * 定数をプロパティの変換規則に従い変換する。
          */
-        if(left instanceof PropertyPath && right instanceof Constant) {
-            visitConstantWithPropertyPath((PropertyPath<?>)left, (Constant<?>)right, rightContext);
+        if(isPropertyPath(left) && right instanceof Constant) {
+            visitConstantWithPropertyPath((Path<?>)left, (Constant<?>)right, rightContext);
         } else {
             invoke(operator, right, visitor, rightContext);
         }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ComparisionOpHandler.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/ComparisionOpHandler.java
@@ -1,5 +1,6 @@
 package com.github.mygreen.sqlmapper.core.where.metamodel;
 
+import com.github.mygreen.sqlmapper.metamodel.Path;
 import com.github.mygreen.sqlmapper.metamodel.PropertyPath;
 import com.github.mygreen.sqlmapper.metamodel.Visitor;
 import com.github.mygreen.sqlmapper.metamodel.expression.Constant;
@@ -51,8 +52,8 @@ public class ComparisionOpHandler extends OperationHandler<ComparisionOp> {
          * 比較演算子の場合、左変=プロパティパス、右辺=定数で構成される場合、
          * 定数をプロパティの変換規則に従い変換する。
          */
-        if(left instanceof PropertyPath && right instanceof Constant) {
-            visitConstantWithPropertyPath((PropertyPath<?>)left, (Constant<?>)right, rightContext);
+        if(isPropertyPath(left) && right instanceof Constant) {
+            visitConstantWithPropertyPath((Path<?>)left, (Constant<?>)right, rightContext);
         } else {
             invoke(operator, right, visitor, rightContext);
         }
@@ -83,13 +84,13 @@ public class ComparisionOpHandler extends OperationHandler<ComparisionOp> {
          * 比較演算子の場合、左変=プロパティパス、右辺=定数で構成される場合、
          * 定数をプロパティの変換規則に従い変換する。
          */
-        if(left instanceof PropertyPath && right1 instanceof Constant) {
-            visitConstantWithPropertyPath((PropertyPath<?>)left, (Constant<?>)right1, rightContext1);
+        if(isPropertyPath(left) && right1 instanceof Constant) {
+            visitConstantWithPropertyPath((Path<?>)left, (Constant<?>)right1, rightContext1);
         } else {
             invoke(operator, right1, visitor, rightContext1);
         }
 
-        if(left instanceof PropertyPath && right2 instanceof Constant) {
+        if(isPropertyPath(left) && right2 instanceof Constant) {
             visitConstantWithPropertyPath((PropertyPath<?>)left, (Constant<?>)right2, rightContext2);
         } else {
             invoke(operator, right2, visitor, rightContext2);

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/OperationHandler.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/where/metamodel/OperationHandler.java
@@ -11,7 +11,7 @@ import com.github.mygreen.sqlmapper.core.query.IllegalQueryException;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
 import com.github.mygreen.sqlmapper.core.util.QueryUtils;
 import com.github.mygreen.sqlmapper.metamodel.Path;
-import com.github.mygreen.sqlmapper.metamodel.PropertyPath;
+import com.github.mygreen.sqlmapper.metamodel.PathType;
 import com.github.mygreen.sqlmapper.metamodel.Visitor;
 import com.github.mygreen.sqlmapper.metamodel.expression.Constant;
 import com.github.mygreen.sqlmapper.metamodel.expression.Expression;
@@ -81,13 +81,31 @@ public abstract class OperationHandler<T extends Operator> {
     }
 
     /**
+     * 式がプロパティパスかどうか判定します。
+     * @param exp 式
+     * @return プロパティパスの場合、{@literal true}を返します。
+     */
+    protected boolean isPropertyPath(Expression<?> exp) {
+
+        if(!(exp instanceof Path)) {
+            return false;
+        }
+
+        Path<?> path = (Path<?>) exp;
+        return path.getPathMeta().getType() == PathType.PROPERTY;
+
+    }
+
+    /**
      * プロパティが確定しているのとき定数の処理。
      * @param propertyPath プロパティパス
      * @param expr 定数
      * @param context コンテキスト
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    protected void visitConstantWithPropertyPath(PropertyPath<?> propertyPath, Constant<?> expr, VisitorContext context) {
+    protected void visitConstantWithPropertyPath(Path<?> propertyPath, Constant<?> expr, VisitorContext context) {
+
+        assert propertyPath.getPathMeta().getType() == PathType.PROPERTY;
 
         Path<?> rootPath = propertyPath.getPathMeta().findRootPath();
         Class<?> rootClassType = rootPath.getType();


### PR DESCRIPTION
- プロパティに対する演算子で、定数を指定したときに、ValueType による変換処理が適用されない事象を修正。
  - 列挙型を渡したときに、SQL実行時にJDBC Driverが対応できない型を判定される。
- プロパティの判定条件として `PropertyPath` を使用していたが、VIsitorには PathMixinが渡されるため、判定条件を変更。
- 文字列や数値型は、JDBC Driverが標準で対応しているので今まで気づかなかった。