### PR TITLE
UUIDを文字列として扱うよう処理を変更

### DIFF
--- a/docs/how2entity/column.adoc
+++ b/docs/how2entity/column.adoc
@@ -127,8 +127,8 @@ DBの型は、JDBCドライバがサポートしていれば、対応してい�
 |
 
 |java.util.UUID
-|UUID
-|
+|VARCHAR
+|UUID型をサポートしているDBも多くありますが、JDBCドライバーがそれぞれ対応方法が異なるため、SqlMapperではDB側は文字列型に変換して永続化します。もし、DB固有のUUIDを使用したい場合は、``@Convert`` で独自の型変換処理を実装して対応する必要があります。
 
 |列挙型
 |CHAR / VARCHAR / TINTYINT / SMALLINT / INTEGER

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/standard/UUIDType.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/standard/UUIDType.java
@@ -5,13 +5,12 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.UUID;
 
-import org.springframework.jdbc.core.SqlParameterValue;
-
 import com.github.mygreen.sqlmapper.core.dialect.Dialect;
 import com.github.mygreen.sqlmapper.core.type.ValueType;
 
 /**
- * {@link UUID} 型のマッピングを処理します。
+ * 文字列型を{@link UUID} 型のマッピングを処理します。
+ * <p>DB側がUUID型に対応していない場合、永続化する際に文字列に変換して対応します。
  *
  *
  * @author T.TSUCHIE
@@ -21,16 +20,22 @@ public class UUIDType implements ValueType<UUID> {
 
     @Override
     public UUID getValue(ResultSet rs, int columnIndex) throws SQLException {
-        return (UUID)rs.getObject(columnIndex);
+        Object value = rs.getObject(columnIndex);
+        return value != null ? UUID.fromString(value.toString()) : null;
     }
 
     @Override
     public Object getSqlParameterValue(UUID value) {
-        return new SqlParameterValue(Types.OTHER, value);
+        /*
+         * UUIDのオブジェクト型を使用する場合
+         * ・PostgreSQLの場合は、OTHERで型指定が必要。
+         * ・H2DBの場合は、逆にOTHER指定でエラーが出るため、何も指定しない。
+         */
+        return value != null ? value.toString() : null;
     }
 
     @Override
     public int getSqlType(Dialect dialect) {
-        return Types.OTHER;
+        return Types.VARCHAR;
     }
 }


### PR DESCRIPTION
- JDBCドライバことにUUIDの扱い方法が異なるため、文字列型に変換して対応するよう変更。
- DB側をUUID型で使用したい場合は、``@Converter`` で独自の変換処理を作成して対応する。