### PR TITLE
自動採番のフォーマット指定の修正

### DIFF
--- a/docs/how2entity/generated_id.adoc
+++ b/docs/how2entity/generated_id.adoc
@@ -1,7 +1,7 @@
 [[anno_generated_id]]
 = 識別子（ID）の自動採番
 
-主キーなどの識別子（ID）の値をを自動生成したい場合は、フィールドにアノテーション ``@GeneratedId`` を付与します。
+主キーなどの識別子（ID）の値をを自動生成したい場合は、フィールドにアノテーション ``@GeneratedValue`` を付与します。
 
 * 属性 ``strategy`` にて生成方法を指定します。
 * 属性 ``generator`` にて、独自の生成方法を実装を指定することもできます。
@@ -32,7 +32,7 @@ public class User {
 |データベースにより生成方法が自動手的に選択されます。 
 
 * 選択される方法は、DBダイアクレクト ``Dialect#getDefaultGenerationType()`` により決定されます。 
-* strateryを指定しなければ、``AUTO`` と解釈されます。 
+* strategyを指定しなければ、``AUTO`` と解釈されます。 
 
 |``@GeneratedValue(strategry=GenerationType.IDENTITY)``
 |IDENTITY列を使用して採番を行います。
@@ -41,7 +41,7 @@ public class User {
 * IDENTITY列をサポートしているDBMSのみ利用できます。
 
 |``@GeneratedValue(strategy=GenerationType.SEQUENCE)``
-|DBのシーケンスを使用して採番を行います。
+|<<anno_sequence_gnerarator,シーケンスを使用して採番>>を行います。
 
 * アノテーション ``@SequenceGenerator``にて、詳細に定義することができます。
 * シーケンスをサポートしているDBMSのみ利用できます。
@@ -55,12 +55,61 @@ public class User {
 |``@GeneratedValue(strategy=GenerationType.UUID)``
 |``java.util.UUID`` を使用しランダムなセキュアな値を生成します。
 
-|``@GeneratedValue(generator=<独自実装)``
-|　<<custom_id_gnerarator,独自の採番方式>>として、Springコンテナに登録されているBean名を指定します。
+|``@GeneratedValue(generator=<独自実装>)``
+|<<custom_id_gnerarator,独自の採番方式>>として、Springコンテナに登録されているBean名を指定します。
 
 * 指定するSpring Beanは、インタフェース ``com.github.mygreen.sqlmapper.core.id.IdGenerator`` を実装する必要があります。
 
 |===
+
+[[anno_sequence_gnerarator]]
+== シーケンスによる識別子（ID）の自動採番
+
+* シーケンスをサポートしているDBMSで利用できます。
+
+* 利用する際には、事前に採番用のシーケンスを定義しておく必要があります。
+** シーケンス名は、アノテーション ``@SequenceGenerator`` でカスタマイズすることができます。
+** アノテーション ``@SequenceGenerator`` でシーケンス名を指定しない場合は、「``<テーブル名>_<カラム名>``」のシーケンス名を使用します。
+* 文字列にマッピングする際に、``@SequenceGenerator(format="xxx")`` でフォーマットを指定することができます。
+** フォーマットは、``java.text.DecimalFormat`` で解釈可能な書式を指定します。
+
+.採番用シーケンスのDDL
+[source,sql]
+----
+-- シーケンス名(<テーブル名>_<カラム名>)
+CREATE SEQUENCE USER_ID start with 1;
+----
+
+.標準的な使い方
+[source,java]
+----
+@Entity
+public class User {
+    
+    @Id
+    @GeneratedValue(strategry=GenerationType.SEQUENCE)
+    private long id;
+
+    private String name;
+    // setter/getterメソッドは省略
+}
+----
+
+.文字列型にフォーマット指定で採番する場合
+[source,java]
+----
+@Entity
+public class User {
+    
+    @Id
+    @SequenceGenerator(format="0000000000")
+    @GeneratedValue(strategry=GenerationType.SEQUENCE)
+    private String id;
+
+    private String name;
+    // setter/getterメソッドは省略
+}
+----
 
 
 [[anno_table_gnerarator]]
@@ -70,6 +119,8 @@ IDENTITYやシーケンスなどの機能を使わないで、テーブルを使
 
 * 利用する際には、事前に採番用のテーブルを定義しておく必要があります。
 ** テーブル名、カラム名などは、アノテーション ``@TableGenerator`` または、<<available_properties,プロパティ>> によってカスタマイズすることができます。
+* 文字列にマッピングする際に、``@TableGenerator(format="xxx")`` でフォーマットを指定することができます。
+** フォーマットは、``java.text.DecimalFormat`` で解釈可能な書式を指定します。
 
 .採番用テーブルのDDL
 [source,sql]
@@ -96,6 +147,23 @@ public class User {
     // setter/getterメソッドは省略
 }
 ----
+
+.文字列型にフォーマット指定で採番する場合
+[source,java]
+----
+@Entity
+public class User {
+    
+    @Id
+    @TableGenerator(format="0000000000")
+    @GeneratedValue(strategry=GenerationType.TABLE)
+    private String id;
+
+    private String name;
+    // setter/getterメソッドは省略
+}
+----
+
 
 === テーブルによる識別子の自動生成の設定
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/GeneratedValue.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/GeneratedValue.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.text.DecimalFormat;
 
 import com.github.mygreen.sqlmapper.core.dialect.Dialect;
 import com.github.mygreen.sqlmapper.core.id.IdGenerator;
@@ -34,12 +33,6 @@ public @interface GeneratedValue {
      * <p>{@link IdGenerator} を実装している必要があります。
      */
     String generator() default "";
-
-    /**
-     * 識別子のクラスタイプが文字列のときに書式を設定することができます。
-     * @return {@link DecimalFormat}で指定できる書式です。
-     */
-    String format() default "";
 
     /**
      * 主キー生成戦略の種別を定義します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/SequenceGenerator.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/SequenceGenerator.java
@@ -5,10 +5,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.text.DecimalFormat;
 
 /**
  * 識別子(主キー)の値をシーケンスにより採番する設定をします。
- *
  *
  * @author T.TSUCHIE
  *
@@ -34,5 +34,11 @@ public @interface SequenceGenerator {
      * (オプション) 主キーの値を取得するデータベースのシーケンスオブジェクトの名前。
      */
     String sequenceName() default "";
+
+    /**
+     * 識別子のクラスタイプが文字列のときに書式を設定することができます。
+     * @return {@link DecimalFormat}で指定できる書式です。
+     */
+    String format() default "";
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/TableGenerator.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/TableGenerator.java
@@ -5,11 +5,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.text.DecimalFormat;
 
 /**
  * 識別子(主キー)の値をテーブルにより採番する設定をします。
  * <p>このアノテーションは {@link Id}、{@link GeneratedValue} と併わせて使用しなければいけません。</p>
- *
  *
  * @author T.TSUCHIE
  *
@@ -67,5 +67,11 @@ public @interface TableGenerator {
      * @return
      */
     long initialValue() default 0L;
+
+    /**
+     * 識別子のクラスタイプが文字列のときに書式を設定することができます。
+     * @return {@link DecimalFormat}で指定できる書式です。
+     */
+    String format() default "";
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/id/IdentityIdGenerator.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/id/IdentityIdGenerator.java
@@ -1,6 +1,5 @@
 package com.github.mygreen.sqlmapper.core.id;
 
-import java.text.NumberFormat;
 import java.util.List;
 
 import org.springframework.dao.DataIntegrityViolationException;
@@ -8,7 +7,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import com.github.mygreen.sqlmapper.core.util.NumberConvertUtils;
 
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 /**
  * IDENTITYによる生成は、実際にはJdbcTemplateで行います。
@@ -25,18 +23,12 @@ public class IdentityIdGenerator implements IdGenerator {
      * サポートしているクラスタイプ
      */
     private static final List<Class<?>> SUPPORTED_TYPE_LIST = List.of(
-            long.class, Long.class, int.class, Integer.class, String.class);
+            long.class, Long.class, int.class, Integer.class);
 
     /**
      * 生成する識別子のタイプ
      */
     private final Class<?> requiredType;
-
-    /**
-     * 文字列にマッピングするときのフォーマッター
-     */
-    @Setter
-    private NumberFormat formatter;
 
     @Override
     public boolean isSupportedType(Class<?> type) {
@@ -68,16 +60,6 @@ public class IdentityIdGenerator implements IdGenerator {
         if(requiredType == long.class || requiredType == Long.class
                 || requiredType == int.class || requiredType == Integer.class) {
             return NumberConvertUtils.convertNumber(requiredType, value);
-
-        } else if(requiredType == String.class) {
-
-            if(formatter == null) {
-                return value.toString();
-            } else {
-                synchronized (formatter) {
-                    return formatter.format(value);
-                }
-            }
 
         }
 


### PR DESCRIPTION
- 自動採番のフォーマットの指定を `@GeneratedValue(forrmat="xxx")` から削除し、`@SequenceGenerator(format="xxx")` / `@TableGenerator(format="xxx")` で指定するよう修正。
- IdentityやUUIDなどは指定しても意味がないため、機能が有効なもののみ指定するよう変更。