### PR TITLE
deleteBatchの呼び出し間違い／パラメータの受け渡し方法の間違いを修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/SqlMapper.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/SqlMapper.java
@@ -8,6 +8,8 @@ import com.github.mygreen.splate.SqlTemplateContext;
 import com.github.mygreen.sqlmapper.core.query.IllegalOperateException;
 import com.github.mygreen.sqlmapper.core.query.auto.AutoAnyDelete;
 import com.github.mygreen.sqlmapper.core.query.auto.AutoAnyDeleteImpl;
+import com.github.mygreen.sqlmapper.core.query.auto.AutoBatchDelete;
+import com.github.mygreen.sqlmapper.core.query.auto.AutoBatchDeleteImpl;
 import com.github.mygreen.sqlmapper.core.query.auto.AutoBatchInsert;
 import com.github.mygreen.sqlmapper.core.query.auto.AutoBatchInsertImpl;
 import com.github.mygreen.sqlmapper.core.query.auto.AutoBatchUpdate;
@@ -158,8 +160,8 @@ public class SqlMapper {
      * @throws IllegalOperateException 引数で指定したエンティティの並びが空のときにスローされます。
      */
     @SuppressWarnings("unchecked")
-    public <T> AutoBatchUpdate<T> deleteBatch(T... entities) {
-        return new AutoBatchUpdateImpl<T>(context, entities);
+    public <T> AutoBatchDelete<T> deleteBatch(T... entities) {
+        return new AutoBatchDeleteImpl<T>(context, entities);
     }
 
     /**
@@ -169,8 +171,8 @@ public class SqlMapper {
      * @return バッチ削除を行うSQLを自動生成するクエリ
      * @throws IllegalOperateException 引数で指定したエンティティの並びが空のときにスローされます。
      */
-    public <T> AutoBatchUpdate<T> deleteBatch(Collection<T> entities) {
-        return new AutoBatchUpdateImpl<T>(context, entities);
+    public <T> AutoBatchDelete<T> deleteBatch(Collection<T> entities) {
+        return new AutoBatchDeleteImpl<T>(context, entities);
     }
 
     /**

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDeleteExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchDeleteExecutor.java
@@ -113,7 +113,7 @@ public class AutoBatchDeleteExecutor {
         where.accept(visitor);
 
         this.whereClause.addSql(visitor.getCriteria());
-        this.paramValues.add(visitor.getParamValues());
+        this.paramValues.addAll(visitor.getParamValues());
     }
 
     /**


### PR DESCRIPTION
- deleteBatchの呼び出しを間違えて、`AutoUpdateBatch` になっていたのを `AUtoDeleteBatch` に修正。
- 削除時のwhere 条件のクエリのパラメータの設定方法の間違いを修正。