### PR TITLE
TableIdGeneratorのキャッシュリフレッシュ機能を追加

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/id/AllocatableIdGenerator.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/id/AllocatableIdGenerator.java
@@ -50,8 +50,19 @@ public abstract class AllocatableIdGenerator {
      * @return 新たらしいID
      */
     public long nextValue(final String key) {
-        return allocatedIdCache.computeIfAbsent(key, k -> new AllocatedIdContext()).getNextValue(key);
+        return allocatedIdCache.computeIfAbsent(key, k -> new AllocatedIdContext(key)).getNextValue();
 
+    }
+
+    /**
+     * IDのキャッシュ情報をクリアします。
+     * <p>クリアすることで、次回、{@link #nextValue(String)}を呼び出した時に、最新のDBの情報を反映した状態になります。
+     *
+     * @since 0.3
+     * @param key 割り当てるキーの名称
+     */
+    protected void clear(final String key) {
+        allocatedIdCache.remove(key);
     }
 
     /**
@@ -61,7 +72,13 @@ public abstract class AllocatableIdGenerator {
      * @author T.TSUCHIE
      *
      */
+    @RequiredArgsConstructor
     public class AllocatedIdContext {
+
+        /**
+         * 生成用のキー
+         */
+        private final String key;
 
         /**
          * 現在値
@@ -80,7 +97,7 @@ public abstract class AllocatableIdGenerator {
          * @param key キー名
          * @return 新しいIDを返します。
          */
-        public synchronized long getNextValue(final String key) {
+        public synchronized long getNextValue() {
 
             if(currentValue < 0l) {
                 this.currentValue = getCurrentValue(key);

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/id/TableIdGenerator.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/id/TableIdGenerator.java
@@ -87,4 +87,12 @@ public class TableIdGenerator implements IdGenerator {
         throw new DataIntegrityViolationException("not supported java type : " + requiredType.getName());
 
     }
+
+    /**
+     * IDのキャッシュ情報をクリアします。
+     * <p>クリアすることで、次回、{@link #generateValue(IdGenerationContext)}を呼び出した時に、最新のDBの情報を反映した状態になります。
+     */
+    public void clearCache() {
+        incrementer.clear(sequenceName);
+    }
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/EntityMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/EntityMetaFactory.java
@@ -20,6 +20,7 @@ import com.github.mygreen.sqlmapper.core.annotation.Entity;
 import com.github.mygreen.sqlmapper.core.annotation.MappedSuperclass;
 import com.github.mygreen.sqlmapper.core.annotation.Table;
 import com.github.mygreen.sqlmapper.core.annotation.Version;
+import com.github.mygreen.sqlmapper.core.id.TableIdGenerator;
 import com.github.mygreen.sqlmapper.core.naming.NamingRule;
 
 import lombok.Getter;
@@ -29,7 +30,7 @@ import lombok.Setter;
 /**
  * エンティティのメタ情報を作成します。
  *
- *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
@@ -73,6 +74,21 @@ public class EntityMetaFactory {
      */
     public void clear() {
         this.entityMetaMap.clear();
+    }
+
+    /**
+     * IDのテーブルによる自動採番のキャッシュ情報をクリアします。
+     * クリアすることで、次に採番するときに、最新のDBの情報を反映した状態になります。
+     * @since 0.3
+     */
+    public void refreshTableIdGenerator() {
+
+        entityMetaMap.values().stream()
+            .flatMap(e -> e.getIdPropertyMetaList().stream())
+            .filter(p -> p.getIdGenerator().isPresent() && (p.getIdGenerator().get() instanceof TableIdGenerator))
+            .map(p -> (TableIdGenerator)(p.getIdGenerator().get()))
+            .forEach(g -> g.clearCache());
+
     }
 
     /**


### PR DESCRIPTION
- テスト時などにテーブルをクリアしたときにキャッシュ情報をクリアする必要があったためメソッドを追加。