### PR TITLE
getOptionalRsultで複数件見つかったときに例外をスローするよう修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelect.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 import com.github.mygreen.sqlmapper.core.query.IllegalOperateException;
@@ -205,7 +206,8 @@ public interface AutoSelect<T> {
      * 検索してベースオブジェクトを返します。
      *
      * @return ベースオブジェクト。
-     * @throws IncorrectResultSizeDataAccessException 1件も見つからない場合、2件以上見つかった場合にスローされます。
+     * @throws EmptyResultDataAccessException 1件も見つからなかった場合にスローされます。
+     * @throws IncorrectResultSizeDataAccessException 2件以上見つかった場合にスローされます。
      */
     T getSingleResult();
 
@@ -213,6 +215,7 @@ public interface AutoSelect<T> {
      * 検索してベースオブジェクトを返します。
      *
      * @return ベースオブジェクト。1件も対象がないときは空を返します。
+     * @throws IncorrectResultSizeDataAccessException 2件以上見つかった場合にスローされます。
      */
     Optional<T> getOptionalResult();
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelectExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoSelectExecutor.java
@@ -566,6 +566,7 @@ public class AutoSelectExecutor<T> {
      *
      * @param callback エンティティマッピング後のコールバック処理。
      * @return エンティティのベースオブジェクト。1件も対象がないときは空を返します。
+     * @throws IncorrectResultSizeDataAccessException 2件以上見つかった場合にスローされます。
      */
     public Optional<T> getOptionalResult(EntityMappingCallback<T> callback) {
         prepare();
@@ -575,6 +576,8 @@ public class AutoSelectExecutor<T> {
         final List<T> ret = getJdbcTemplate().query(executedSql, rowMapper, paramValues.toArray());
         if(ret.isEmpty()) {
             return Optional.empty();
+        } else if(ret.size() > 1) {
+            throw new IncorrectResultSizeDataAccessException(1, ret.size());
         } else {
             return Optional.of(ret.get(0));
         }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelect.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 /**
@@ -55,7 +56,8 @@ public interface SqlSelect<T> {
      * 検索してベースオブジェクトを返します。
      *
      * @return ベースオブジェクト。
-     * @throws IncorrectResultSizeDataAccessException 1件も見つからない場合、2件以上見つかった場合にスローされます。
+     * @throws EmptyResultDataAccessException 1件も見つからなかった場合にスローされます。
+     * @throws IncorrectResultSizeDataAccessException 2件以上見つかった場合にスローされます。
      */
     T getSingleResult();
 
@@ -63,6 +65,7 @@ public interface SqlSelect<T> {
      * 検索してベースオブジェクトを返します。
      *
      * @return ベースオブジェクト。1件も対象がないときは空を返します。
+     * @throws IncorrectResultSizeDataAccessException 2件以上見つかった場合にスローされます。
      */
     Optional<T> getOptionalResult();
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectExecutor.java
@@ -90,6 +90,7 @@ public class SqlSelectExecutor<T> {
      *
      * @param callback エンティティマッピング後のコールバック処理。
      * @return エンティティのベースオブジェクト。1件も対象がないときは空を返します。
+     * @throws IncorrectResultSizeDataAccessException 2件以上見つかった場合にスローされます。
      */
     public Optional<T> getOptionalResult(EntityMappingCallback<T> callback) {
         prepare();
@@ -98,6 +99,8 @@ public class SqlSelectExecutor<T> {
         final List<T> ret = getJdbcTemplate().query(executedSql, rowMapper, paramValues);
         if(ret.isEmpty()) {
             return Optional.empty();
+        } else if(ret.size() > 1) {
+            throw new IncorrectResultSizeDataAccessException(1, ret.size());
         } else {
             return Optional.of(ret.get(0));
         }


### PR DESCRIPTION
- `getOptionalRsult` で複数件見つかったときに例外 `IncorrectResultSizeDataAccessException` をスローするよう変更。
  - 修正前は、複数件見つかった場合は先頭の1件を返していた。
- `getSingleResult` で0件のとき例外を、`IncorrectResultSizeDataAccessException`  の サブクラス `EmptyResultDataAccessException` に変更。 