### PR TITLE
SQLファイル実行時にcount/offset/limit句を自動的に付与するよう修正

### DIFF
--- a/docs/autoquery/select.adoc
+++ b/docs/autoquery/select.adoc
@@ -21,7 +21,8 @@ List<Employee> results = sqlMapper.selectFrom(MEmployee.employee)
 
 1件検索する場合は、`getSingleResult()` を使用します。
 
-* 1件も見つからない、または、2件以上見つかった場合、Springの例外 `IncorrectResultSizeDataAccessException` がスローされます。
+* 1件も見つからないときは、Springの例外 `EmptyResultDataAccessException` がスローされます。
+* 2件以上見つかった場合、Springの例外 `IncorrectResultSizeDataAccessException` がスローされます。
 
 [source,java]
 ----
@@ -29,7 +30,7 @@ Employee result = sqlMapper.selectFrom(MEmployee.employee)
         .getSingleResult();
 ----
 
-0件/複数件見つかったときに例外をスローされないようにするには、`getOptionalResult()` を使用します。
+1件も見つかったときに例外をスローされないようにするには、`getOptionalResult()` を使用します。
 
 * 戻り値を `java.util.Optinal` で受け取ることができます。
 
@@ -269,10 +270,10 @@ List<Employee> results = sqlMapper.selectFrom(e)
 
 ページングを指定するには、以下のメソッドを使用します。
 
-* `limit(int limit)` : 取得する行数を指定します。
 * `offset(int offset)` : 最初に取得する行の位置を指定します。最初の行の位置は0になります。 
+* `limit(int limit)` : 取得する行数を指定します。
 
-ページングを指定するには、必ず <<select_order_by,並び順>> の指定も必要です。
+NOTE: ページングを指定するには、必ず <<select_order_by,並び順>> の指定も必要です。
 
 [source,java]
 ----
@@ -280,8 +281,8 @@ MEmployee e = MEmployee.employee;
 
 List<Employee> results = sqlMapper.selectFrom(e)
         .orderBy(e.name.asc(), e.hireDate.desc())
-        .limit(100)
         .offset(10)
+        .limit(100)
         .getResultList();
 ----
 

--- a/docs/filequery/select.adoc
+++ b/docs/filequery/select.adoc
@@ -21,7 +21,8 @@ List<Employee> results = sqlMapper.selectBySqlFile(
 
 SQLファイルを使って1件検索をする場合は、 `selectBySqlFile(...)` と `getSingleResult()` を組み合わせます。
 
-* 1件も見つからない、または、2件以上見つかった場合、Springの例外 `IncorrectResultSizeDataAccessException` がスローされます。
+* 1件も見つからないときは、Springの例外 `EmptyResultDataAccessException` がスローされます。
+* 2件以上見つかった場合、Springの例外 `IncorrectResultSizeDataAccessException` がスローされます。
 
 [source,java]
 ----
@@ -35,7 +36,7 @@ Employee result = sqlMapper.sqlMapper.selectBySqlFile(
         .getSingleResult();
 ----
 
-0件/複数件見つかったときに例外をスローされないようにするには、`getOptionalResult()` を使用します。
+1件も見つからなかったときに例外をスローされないようにするには、`getOptionalResult()` を使用します。
 
 * 戻り値を `java.util.Optinal` で受け取ることができます。
 
@@ -91,6 +92,8 @@ List<Employee> results = sqlMapper.selectBySqlFile(
 
 `SELECT COUNT(*) ～` による検索結果の行数を取得するには、`getCountBySqlFile(...)` を使用します。
 
+NOTE: SQLファイルで定義したSQLを、`select count(*) from (<SQLテンプレートの内容>)` に変換して実行されるため、`count` 句をSQLテンプレートに記載する必要はありません。
+
 [source,java]
 ----
 SqlTemplateContext templateContext = new MapSqlTemplateContext(
@@ -102,4 +105,34 @@ long count = sqlMapper.selectBySqlFile(
             templateContext)
             getCount();
 ----
+
+
+== ページング
+
+ページングを指定するには、以下のメソッドを使用します。
+
+* `offset(int offset)` : 最初に取得する行の位置を指定します。最初の行の位置は0になります。 
+* `limit(int limit)` : 取得する行数を指定します。
+
+[NOTE]
+====
+ * SQLファイルで定義したSQLを、`<SQLテンプレートの内容> offset <開始位置> limit <取得行数>` に変換して実行されるため、`offset`/`limit` 句をSQLテンプレートに記載する必要はありません。
+ * 並び順が一定になるように、SQLテンプレート内で並び順を指定しておく必要があります。
+====
+
+
+[source,java]
+----
+SqlTemplateContext templateContext = new MapSqlTemplateContext(
+        Map.of("salary", nwe BigDecimal(2000)));
+
+List<Employee> results = sqlMapper.selectBySqlFile(
+            Employee.class, 
+            "examples/sql/employee/selectAll.sql", 
+            templateContext)
+        .offset(10)
+        .limit(100)
+        .getResultList();
+----
+
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/Dialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/Dialect.java
@@ -68,6 +68,14 @@ public interface Dialect {
     String getCountSql();
 
     /**
+     * 件数取得用のSQLに変換します。
+     * @param sql SQL
+     * @return 件数取得用SQL
+     * @throws IllegalArgumentException 引数{@literal sql}が空の場合にスローされます。
+     */
+    String convertGetCountSql(String sql);
+
+    /**
      * ヒントコメントを返します。
      * <p>ヒント句をサポートしていないDBの場合は空文字を返します。</p>
      *

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/DialectBase.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/DialectBase.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
 import com.github.mygreen.sqlmapper.core.query.SelectForUpdateType;
@@ -52,6 +53,16 @@ public abstract class DialectBase implements Dialect {
     @Override
     public String getCountSql() {
         return "count(*)";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@literal "select count(*) from (<sql>)"} を返します。
+     */
+    public String convertGetCountSql(final String sql) {
+        Assert.hasLength(sql, "sql should be not empty.");
+        return "select count(*) from ( " + sql + " )";
     }
 
     /**

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCountImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCountImpl.java
@@ -55,7 +55,8 @@ public class SqlCountImpl implements SqlCount {
     @Override
     public long getCount() {
         ProcessResult result = template.process(parameter);
-        return getJdbcTemplate().queryForObject(result.getSql(), Long.class, result.getParameters().toArray());
+        String sql = context.getDialect().convertGetCountSql(result.getSql());
+        return getJdbcTemplate().queryForObject(sql, Long.class, result.getParameters().toArray());
 
     }
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelect.java
@@ -10,7 +10,7 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 /**
  * SQLテンプレートによる抽出を行うクエリです。
  *
- * @version0 .3
+ * @version 0.3
  * @author T.TSUCHIE
  *
  * @param <T> 処理対象のエンティティの型
@@ -51,6 +51,24 @@ public interface SqlSelect<T> {
      * @return 自身のインスタンス。
      */
     SqlSelect<T> maxRows(int maxRows);
+
+    /**
+     * 抽出する行数を指定します。
+     *
+     * @since 0.3
+     * @param limit 行数
+     * @return このインスタンス自身
+     */
+    SqlSelect<T> limit(int limit);
+
+    /**
+     * 抽出するデータの開始位置を指定します。
+     *
+     * @since 0.3
+     * @param offset 開始位置。0から始まります。
+     * @return このインスタンス自身
+     */
+    SqlSelect<T> offset(int offset);
 
     /**
      * 検索してベースオブジェクトを返します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectExecutor.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.github.mygreen.splate.ProcessResult;
 import com.github.mygreen.sqlmapper.core.SqlMapperContext;
+import com.github.mygreen.sqlmapper.core.dialect.Dialect;
 import com.github.mygreen.sqlmapper.core.mapper.EntityMappingCallback;
 import com.github.mygreen.sqlmapper.core.mapper.SqlEntityRowMapper;
 import com.github.mygreen.sqlmapper.core.query.JdbcTemplateBuilder;
@@ -66,7 +67,14 @@ public class SqlSelectExecutor<T> {
     private void prepareSql() {
 
         final ProcessResult result = query.getTemplate().process(query.getParameter());
-        this.executedSql = result.getSql();
+        final Dialect dialect = context.getDialect();
+
+        String sql = result.getSql();
+        if(query.getLimit() > 0 || query.getOffset() >= 0) {
+            sql = dialect.convertLimitSql(sql, query.getOffset(), query.getLimit());
+        }
+        this.executedSql = sql;
+
         this.paramValues = result.getParameters().toArray();
 
     }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectImpl.java
@@ -55,6 +55,20 @@ public class SqlSelectImpl<T> implements SqlSelect<T> {
     @Getter
     private Integer maxRows;
 
+    /**
+     * 取得するレコード数の上限値です。
+     * <p>負の値の時は無視します。
+     */
+    @Getter
+    private int limit = -1;
+
+    /**
+     * 取得するレコード数の開始位置です。
+     * <p>負の値の時は無視します。
+     */
+    @Getter
+    private int offset = -1;
+
     public SqlSelectImpl(@NonNull SqlMapperContext context, @NonNull Class<T> baseClass,
             @NonNull SqlTemplate template, @NonNull SqlTemplateContext parameter) {
 
@@ -81,6 +95,18 @@ public class SqlSelectImpl<T> implements SqlSelect<T> {
     @Override
     public SqlSelectImpl<T> maxRows(int maxRows) {
         this.maxRows = maxRows;
+        return this;
+    }
+
+    @Override
+    public SqlSelectImpl<T> limit(int limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    @Override
+    public SqlSelectImpl<T> offset(int offset) {
+        this.offset = offset;
         return this;
     }
 


### PR DESCRIPTION
- `getCountBySql` 実行時に、`select count(*) from (<SQLファイルの内容>)` のように、自動的にcount句を付与するよう修正、
- `selectBySql` 事項時に、offset/limit 句を指定できる機能を追加。 