### PR TITLE
LOBの対応の修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/EntityMetamodelFactory.java
+++ b/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/EntityMetamodelFactory.java
@@ -16,6 +16,7 @@ import com.github.mygreen.sqlmapper.apt.model.PropertyMetamodel;
 import com.github.mygreen.sqlmapper.core.annotation.Embeddable;
 import com.github.mygreen.sqlmapper.core.annotation.EmbeddedId;
 import com.github.mygreen.sqlmapper.core.annotation.Entity;
+import com.github.mygreen.sqlmapper.core.annotation.Lob;
 import com.github.mygreen.sqlmapper.core.annotation.MappedSuperclass;
 import com.github.mygreen.sqlmapper.core.annotation.Transient;
 import com.github.mygreen.sqlmapper.core.meta.EntityMetaFactory;
@@ -26,6 +27,7 @@ import lombok.RequiredArgsConstructor;
  * クラス情報からメタモデルの情報を作成します。
  * プロパティやクラスの仕様は、{@link EntityMetaFactory}に準拠します。
  *
+ * @version 0.3
  * @author T.TSUCHIE
  *
  */
@@ -131,6 +133,9 @@ public class EntityMetamodelFactory {
 
         // 埋め込み用かどうか
         propertyModel.setEmbedded(fieldElement.getAnnotation(EmbeddedId.class) != null);
+
+        // LOBかどうか
+        propertyModel.setLob(fieldElement.getAnnotation(Lob.class) != null);
 
         return propertyModel;
 

--- a/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/EntitySpecFactory.java
+++ b/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/EntitySpecFactory.java
@@ -86,7 +86,14 @@ public class EntitySpecFactory {
         final AptType propertyType = propertyModel.getPropertyType();
 
         FieldSpec filedSpec;
-        if(propertyModel.isEmbedded()) {
+        if(propertyModel.isCustomType() || propertyModel.isLob()) {
+            // 対応できない型の場合、汎用的なGeneralPathにする
+            TypeName filedTypeName = ParameterizedTypeName.get(ClassName.get(GeneralPath.class), propertyType.getTypeName());
+            filedSpec = FieldSpec.builder(filedTypeName, propertyModel.getPropertyName(), Modifier.PUBLIC, Modifier.FINAL)
+                    .initializer("createGeneral($S, $T.class)", propertyModel.getPropertyName(), propertyType.getTypeName())
+                    .build();
+
+        } else if(propertyModel.isEmbedded()) {
             // 埋め込み用のプロパティの場合
             // public final MPK id = new MPK(this, "id")
             String embeddedEntityMetamodelName = resolveEntityMetamodelName(propertyType.getSimpleName());

--- a/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/model/PropertyMetamodel.java
+++ b/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/model/PropertyMetamodel.java
@@ -41,4 +41,14 @@ public class PropertyMetamodel {
      */
     private boolean embedded;
 
+    /**
+     * LOB（ラージオブジェクト）かどうか。
+     */
+    private boolean lob;
+
+    /**
+     * 独自のConverterが適用される場合
+     */
+    private boolean customType;
+
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchInsertExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoBatchInsertExecutor.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.SqlParameterValue;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.jdbc.support.KeyHolder;
@@ -140,7 +141,12 @@ public class AutoBatchInsertExecutor {
 
                 // クエリのパラメータの組み立て
                 ValueType valueType = propertyMeta.getValueType();
-                paramSource.addValue(columnName, valueType.getSqlParameterValue(propertyValue));
+                Object paramValue = valueType.getSqlParameterValue(propertyValue);
+                if(paramValue instanceof SqlParameterValue) {
+                    // SimpleJdbcInsert を使用する際は、テーブルのコンテキストを見るので、型情報は不要。
+                    paramValue = ((SqlParameterValue)paramValue).getValue();
+                }
+                paramSource.addValue(columnName, paramValue);
 
             }
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsertExecutor.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/auto/AutoInsertExecutor.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.SqlParameterValue;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.jdbc.support.KeyHolder;
@@ -130,7 +131,12 @@ public class AutoInsertExecutor {
 
             // クエリのパラメータの組み立て
             ValueType valueType = propertyMeta.getValueType();
-            paramSource.addValue(columnName, valueType.getSqlParameterValue(propertyValue));
+            Object paramValue = valueType.getSqlParameterValue(propertyValue);
+            if(paramValue instanceof SqlParameterValue) {
+                // SimpleJdbcInsert を使用する際は、テーブルのコンテキストを見るので、型情報は不要。
+                paramValue = ((SqlParameterValue)paramValue).getValue();
+            }
+            paramSource.addValue(columnName, paramValue);
 
         }
     }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/ValueTypeRegistry.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/ValueTypeRegistry.java
@@ -1,6 +1,8 @@
 package com.github.mygreen.sqlmapper.core.type;
 
 import java.math.BigDecimal;
+import java.sql.Blob;
+import java.sql.Clob;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -26,6 +28,8 @@ import com.github.mygreen.sqlmapper.core.meta.PropertyMeta;
 import com.github.mygreen.sqlmapper.core.meta.StoredPropertyMeta;
 import com.github.mygreen.sqlmapper.core.type.enumeration.EnumOrdinalType;
 import com.github.mygreen.sqlmapper.core.type.enumeration.EnumStringType;
+import com.github.mygreen.sqlmapper.core.type.lob.BLobType;
+import com.github.mygreen.sqlmapper.core.type.lob.CLobType;
 import com.github.mygreen.sqlmapper.core.type.lob.LobByteArrayType;
 import com.github.mygreen.sqlmapper.core.type.lob.LobStringType;
 import com.github.mygreen.sqlmapper.core.type.standard.BigDecimalType;
@@ -127,6 +131,8 @@ public class ValueTypeRegistry implements InitializingBean {
 
         // その他の型の設定
         register(UUID.class, new UUIDType());
+        register(Blob.class, new BLobType());
+        register(Clob.class, new CLobType());
 
     }
 
@@ -233,7 +239,14 @@ public class ValueTypeRegistry implements InitializingBean {
     protected ValueType<?> getLobType(final PropertyMeta propertyMeta) {
 
         final Class<?> propertyType = propertyMeta.getPropertyType();
-        if(String.class.isAssignableFrom(propertyType)) {
+
+        if(Clob.class.isAssignableFrom(propertyType)) {
+            return new CLobType();
+
+        } else if(Blob.class.isAssignableFrom(propertyType)) {
+            return new BLobType();
+
+        } else if(String.class.isAssignableFrom(propertyType)) {
             return new LobStringType(lobHandler);
 
         } else if (byte[].class.isAssignableFrom(propertyType)) {

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/lob/BLobType.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/lob/BLobType.java
@@ -1,0 +1,39 @@
+package com.github.mygreen.sqlmapper.core.type.lob;
+
+import java.sql.Blob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import com.github.mygreen.sqlmapper.core.dialect.Dialect;
+import com.github.mygreen.sqlmapper.core.type.SqlParameterBindException;
+import com.github.mygreen.sqlmapper.core.type.SqlValueConversionException;
+import com.github.mygreen.sqlmapper.core.type.ValueType;
+
+
+/**
+ * {@link Blob}型のマッピングを処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+
+public class BLobType implements ValueType<Blob> {
+
+    @Override
+    public int getSqlType(Dialect dialect) {
+        return Types.BLOB;
+    }
+
+    @Override
+    public Blob getValue(ResultSet rs, int columnIndex)
+            throws SQLException, SqlValueConversionException {
+        return rs.getBlob(columnIndex);
+    }
+
+    @Override
+    public Object getSqlParameterValue(Blob value) throws SqlParameterBindException {
+        return value;
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/lob/CLobType.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/lob/CLobType.java
@@ -1,0 +1,38 @@
+package com.github.mygreen.sqlmapper.core.type.lob;
+
+import java.sql.Clob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import com.github.mygreen.sqlmapper.core.dialect.Dialect;
+import com.github.mygreen.sqlmapper.core.type.SqlParameterBindException;
+import com.github.mygreen.sqlmapper.core.type.SqlValueConversionException;
+import com.github.mygreen.sqlmapper.core.type.ValueType;
+
+
+/**
+ * {@link Clob}型のマッピングを処理します。
+ *
+ * @since 0.3
+ * @author T.TSUCHIE
+ *
+ */
+public class CLobType implements ValueType<Clob> {
+
+    @Override
+    public int getSqlType(Dialect dialect) {
+        return Types.CLOB;
+    }
+
+    @Override
+    public Clob getValue(ResultSet rs, int columnIndex)
+            throws SQLException, SqlValueConversionException {
+        return rs.getClob(columnIndex);
+    }
+
+    @Override
+    public Object getSqlParameterValue(Clob value) throws SqlParameterBindException {
+        return value;
+    }
+}

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/lob/LobByteArrayType.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/lob/LobByteArrayType.java
@@ -34,6 +34,9 @@ public class LobByteArrayType implements ValueType<byte[]> {
 
     @Override
     public Object getSqlParameterValue(byte[] value) {
+        if(value == null) {
+            return null;
+        }
         return new SqlParameterValue(Types.BLOB, new SqlLobValue(value, lobHandler));
     }
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/lob/LobStringType.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/type/lob/LobStringType.java
@@ -34,6 +34,9 @@ public class LobStringType implements ValueType<String> {
 
     @Override
     public Object getSqlParameterValue(String value) {
+        if(value == null) {
+            return null;
+        }
         return new SqlParameterValue(Types.CLOB, new SqlLobValue(value, lobHandler));
     }
 


### PR DESCRIPTION
- APTにおいて、Lob型のアノテーションが指定されている場合は、GeneralPathとするよう修正。
- `LobByteArrayType` / `LobStringType`  のinsert/update時に値がnullのときの判定処理を追加。
- `java.sql.Blob` / `java.sql.Clob` 型の対応を追加。
- Insert時に、パラメータ `SqlParameterValue` の場合、エラーとなるため値のみ指定するよう修正する。
  - SImpleJdbcInsertを使用している場合は、DBテーブルのコンテキストを参照しているのでSQLの型情報が不要となるため。
  - upateのように、JdbcTemplate を生で使用する場合は必要。