### PR TITLE
監査情報の不具合の修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/audit/AuditingEntityListener.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/audit/AuditingEntityListener.java
@@ -1,9 +1,11 @@
 package com.github.mygreen.sqlmapper.core.audit;
 
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Date;
 import java.util.Optional;
 
 import org.springframework.beans.factory.InitializingBean;
@@ -11,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 
 import com.github.mygreen.sqlmapper.core.event.PreBatchInsertEvent;
+import com.github.mygreen.sqlmapper.core.event.PreBatchUpdateEvent;
 import com.github.mygreen.sqlmapper.core.event.PreInsertEvent;
 import com.github.mygreen.sqlmapper.core.event.PreUpdateEvent;
 import com.github.mygreen.sqlmapper.core.meta.EntityMeta;
@@ -46,7 +49,7 @@ public class AuditingEntityListener implements InitializingBean {
      *   デフォルトの空の情報を設定します。
      */
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         if(auditorProvider == null) {
             this.auditorProvider = new AuditorProvider<Object>() {
 
@@ -75,7 +78,7 @@ public class AuditingEntityListener implements InitializingBean {
 
         entityMeta.getUpdatedAtPropertyMeta().ifPresent(p -> {
             Object value = getCurrentDateTime(p.getPropertyType());
-            PropertyValueInvoker.setPropertyValue(p, event.getEntity(), value);
+            PropertyValueInvoker.setEmbeddedPropertyValue(p, event.getEntity(), value);
         });
 
         entityMeta.getCreatedByPropertyMeta().ifPresent(p -> {
@@ -101,12 +104,12 @@ public class AuditingEntityListener implements InitializingBean {
 
         entityMeta.getUpdatedAtPropertyMeta().ifPresent(p -> {
             Object value = getCurrentDateTime(p.getPropertyType());
-            PropertyValueInvoker.setPropertyValue(p, event.getEntity(), value);
+            PropertyValueInvoker.setEmbeddedPropertyValue(p, event.getEntity(), value);
         });
 
         entityMeta.getUpdatedByPropertyMeta().ifPresent(p -> {
             Optional<?> value = auditorProvider.getCurrentAuditor();
-            value.ifPresent(v -> PropertyValueInvoker.setPropertyValue(p, event.getEntity(), v));
+            value.ifPresent(v -> PropertyValueInvoker.setEmbeddedPropertyValue(p, event.getEntity(), v));
         });
 
     }
@@ -159,7 +162,7 @@ public class AuditingEntityListener implements InitializingBean {
      * @param event イベント情報。
      */
     @EventListener
-    public void onPreBatchUpdate(final PreBatchInsertEvent event) {
+    public void onPreBatchUpdate(final PreBatchUpdateEvent event) {
 
         final EntityMeta entityMeta = event.getEntityMeta();
 
@@ -187,9 +190,18 @@ public class AuditingEntityListener implements InitializingBean {
      * @throws IllegalArgumentException 引数で指定した {@literal propertyType} がサポートしていない日時型の場合。
      */
     protected Object getCurrentDateTime(final Class<?> propertyType) {
-        if(Date.class.isAssignableFrom(propertyType)) {
-            // java.util.Date の子クラス(java.sql.XXXX) の場合
-            return new Date();
+
+        if(Timestamp.class.isAssignableFrom(propertyType)) {
+            return new Timestamp(System.currentTimeMillis());
+
+        } else if(Time.class.isAssignableFrom(propertyType)) {
+            return new Time(System.currentTimeMillis());
+
+        } else if(Date.class.isAssignableFrom(propertyType)) {
+            return new Date(System.currentTimeMillis());
+
+        } else if(java.util.Date.class.isAssignableFrom(propertyType)) {
+            return new java.util.Date();
 
         } else if(LocalDate.class.isAssignableFrom(propertyType)) {
             return LocalDate.now();


### PR DESCRIPTION
- java.sql.XXXのとき、それぞれのインスタンスを設定。
  - `java.util.Date`  だと、値の設定時にリフレクションのエラーとなる。
- BatchUpdateのときのイベントリスナーの間違いを修正。
  - 間違って、BatchInsertのイベントを定義していた。