### PR TITLE
埋め込み型主キーが自動生成のときの不正なエンティティと判定されてしまう事象を修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMeta.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMeta.java
@@ -37,6 +37,7 @@ public class PropertyMeta extends PropertyBase {
     /**
      * 埋め込み型の主キーの子プロパティかどうか。
      */
+    @Setter
     private boolean embeddedableId = false;
 
     /**

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
@@ -102,12 +102,14 @@ public class PropertyMetaFactory {
      * プロパティのメタ情報を作成します。
      * @param field フィールド
      * @param entityMeta エンティティのメタ情報。空の場合はID情報の処理をスキップします。
+     * @param embeddedId 埋め込み型のIDのプロパティかどうか。
      * @return プロパティのメタ情報
      */
-    public PropertyMeta create(final Field field, final Optional<EntityMeta> entityMeta) {
+    public PropertyMeta create(final Field field, final Optional<EntityMeta> entityMeta, final boolean embeddedId) {
 
         final Class<?> declaringClass = field.getDeclaringClass();
         final PropertyMeta propertyMeta = new PropertyMeta(field.getName(), field.getType());
+        propertyMeta.setEmbeddedableId(embeddedId);
         doField(propertyMeta, field);
 
         // フィールドに対するgetter/setterメソッドを設定します。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
@@ -504,8 +504,8 @@ public class PropertyMetaFactory {
                 && propertyType != Long.class && propertyType != long.class) {
 
             throw new InvalidEntityException(declaringClass, messageFormatter.create("property.anno.notSupportTypeList")
-                    .paramWithClass("entityType", declaringClass)
-                    .param("propperty", propertyMeta.getName())
+                    .paramWithClass("classType", declaringClass)
+                    .param("property", propertyMeta.getName())
                     .paramWithAnno("anno", Id.class)
                     .paramWithClass("actualType", propertyType)
                     .paramWithClass("expectedTypeList", String.class, Integer.class, int.class, Long.class, long.class)
@@ -516,8 +516,8 @@ public class PropertyMetaFactory {
         if(!propertyMeta.isId() && propertyMeta.hasAnnotation(GeneratedValue.class)) {
 
             throw new InvalidEntityException(declaringClass, messageFormatter.create("property.anno.notIdWithGeneratedValue")
-                    .paramWithClass("entityType", declaringClass)
-                    .param("propperty", propertyMeta.getName())
+                    .paramWithClass("classType", declaringClass)
+                    .param("property", propertyMeta.getName())
                     .paramWithAnno("anno", GeneratedValue.class)
                     .format());
         }
@@ -527,8 +527,8 @@ public class PropertyMetaFactory {
         if(propertyMeta.hasAnnotation(Enumerated.class) && !propertyType.isEnum()) {
 
             throw new InvalidEntityException(declaringClass, messageFormatter.create("property.anno.notSupportType")
-                    .paramWithClass("entityType", declaringClass)
-                    .param("propperty", propertyMeta.getName())
+                    .paramWithClass("classType", declaringClass)
+                    .param("property", propertyMeta.getName())
                     .paramWithAnno("anno", Enumerated.class)
                     .paramWithClass("actualType", propertyType)
                     .paramWithClass("expectedType", Enum.class)
@@ -541,8 +541,8 @@ public class PropertyMetaFactory {
                 && propertyType != Long.class && propertyType != long.class) {
 
             throw new InvalidEntityException(declaringClass, messageFormatter.create("property.anno.notSupportTypeList")
-                    .paramWithClass("entityType", declaringClass)
-                    .param("propperty", propertyMeta.getName())
+                    .paramWithClass("classType", declaringClass)
+                    .param("property", propertyMeta.getName())
                     .paramWithAnno("anno", Version.class)
                     .paramWithClass("actualType", propertyType)
                     .paramWithClass("expectedTypeList", Integer.class, int.class, Long.class, long.class)
@@ -556,8 +556,8 @@ public class PropertyMetaFactory {
 
             // 時制の型が不明なプロパティに対して、@Temporalが付与されていない場合
             throw new InvalidEntityException(declaringClass, messageFormatter.create("property.anno.requiredAnnoTemporal")
-                    .paramWithClass("entityType", declaringClass)
-                    .param("propperty", propertyMeta.getName())
+                    .paramWithClass("classType", declaringClass)
+                    .param("property", propertyMeta.getName())
                     .paramWithAnno("anno", Temporal.class)
                     .format());
         }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/StoredParamMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/StoredParamMetaFactory.java
@@ -155,7 +155,7 @@ public class StoredParamMetaFactory {
             }
             ReflectionUtils.makeAccessible(field);
 
-            nestedPropertyMeataList.add(propertyMetaFactory.create(field, Optional.empty()));
+            nestedPropertyMeataList.add(propertyMetaFactory.create(field, Optional.empty(), false));
         }
 
         nestedPropertyMeataList.stream().forEach(p -> propertyMeta.addNestedPropertyMeta(p));


### PR DESCRIPTION
- 埋め込み型主キーの自動生成のとき、PropertyMetaの整合性チェックを埋め込み主キーの属性 `embeddedId` を設定するまえに実行してしまい、主キーではないと判定してしまう事象を修正。
  - 埋め込み型の主キーということを、PropertyMeta生成時に設定するよう変更。
- 例外時のエラーメッセージの変数の間違いを修正。 