### PR TITLE
splateを0.3に更新

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/pom.xml
+++ b/sqlmapper-parent/sqlmapper-core/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>com.github.mygreen</groupId>
 			<artifactId>splate</artifactId>
-			<version>0.2</version>
+			<version>0.3</version>
 		</dependency>
 
 		<dependency>

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlEmbeddedEntityTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlEmbeddedEntityTest.java
@@ -56,8 +56,8 @@ public class SqlEmbeddedEntityTest extends QueryTestSupport {
     void testSqlCountBySql() {
 
         MapSqlTemplateContext templateContext = new MapSqlTemplateContext();
-        templateContext.setVariable("id", new EmbeddedTestEntity.PK(null, 2l));
-        templateContext.setVariable("name", "%@embedded%");
+        templateContext.addVariable("id", new EmbeddedTestEntity.PK(null, 2l));
+        templateContext.addVariable("name", "%@embedded%");
 
         long result = sqlMapper.getCountBySqlFile("/sqltemplate/embedded_selectByAny.sql", templateContext);
 


### PR DESCRIPTION
- splateを0.3にアップデート
- `MapSqlTemplateContext` のメソッド名が変わった部分の修正