### PR TITLE
v0.3.1のバージョン更新

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,7 +1,7 @@
 = SqlMapper
 :lang: ja
-:revision: 0.3
-:app-ver: 0.3
+:revision: 0.3.1
+:app-ver: 0.3.1
 :copyright: Tatsuo TSUCHIE, 2021
 :docinfo: shared
 :doctype: book

--- a/docs/release/index.adoc
+++ b/docs/release/index.adoc
@@ -1,5 +1,6 @@
 = リリースノート
 
 // 各章のインポート
+include::v0_3_1.adoc[leveloffset=+1]
 include::v0_3.adoc[leveloffset=+1]
 include::v0_2.adoc[leveloffset=+1]

--- a/docs/release/v0_3_1.adoc
+++ b/docs/release/v0_3_1.adoc
@@ -1,0 +1,6 @@
+= ver.0.3.1 - 2022-01-13
+
+* https://github.com/mygreen/sqlmapper/pull/50[#50, window="_blank"] - 依存ライブラリであるSQLテンプレートのライブラリ `splate` をv0.3に更新しました。
+
+* https://github.com/mygreen/sqlmapper/pull/51[#51, window="_blank"] - `pom.xml` 定義間違いにより依存関係が解決できない事象を修正しました。
+

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<artifactId>sqlmapper-root</artifactId>
 	<name>SqlMapper</name>
 	<packaging>pom</packaging>
-	<version>${revision}</version>
+	<version>0.3.1</version>
 	<description><![CDATA[ SqlMapperはJavaによるSQLをPOJOにマッピングするライブラリです。 ]]></description>
 	<url>https://mygreen.github.io/sqlmapper/</url>
 
@@ -18,7 +18,7 @@
 	</modules>
 
 	<properties>
-		<revision>0.3</revision>
+		<sqlmapper.version>0.3.1</sqlmapper.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>11</java.version>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-root</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>report-aggregate</artifactId>
@@ -39,22 +39,22 @@
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-core</artifactId>
-			<version>${revision}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-metamodel</artifactId>
-			<version>${revision}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-apt</artifactId>
-			<version>${revision}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-spring-boot-autoconfigure</artifactId>
-			<version>${revision}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/sqlmapper-parent/pom.xml
+++ b/sqlmapper-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-root</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-parent</artifactId>

--- a/sqlmapper-parent/sqlmapper-apt/pom.xml
+++ b/sqlmapper-parent/sqlmapper-apt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-parent</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-apt</artifactId>
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-core</artifactId>
-			<version>${project.version}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 
 		<dependency>

--- a/sqlmapper-parent/sqlmapper-core/pom.xml
+++ b/sqlmapper-parent/sqlmapper-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-parent</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-core</artifactId>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-metamodel</artifactId>
-			<version>${project.version}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 
 		<dependency>

--- a/sqlmapper-parent/sqlmapper-metamodel/pom.xml
+++ b/sqlmapper-parent/sqlmapper-metamodel/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-parent</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-metamodel</artifactId>

--- a/sqlmapper-parent/sqlmapper-spring-boot/pom.xml
+++ b/sqlmapper-parent/sqlmapper-spring-boot/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-parent</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-spring-boot</artifactId>

--- a/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-autoconfigure/pom.xml
+++ b/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-autoconfigure/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-spring-boot</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-spring-boot-autoconfigure</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-core</artifactId>
-			<version>${revision}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 
 		<!-- Spring -->

--- a/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-starter/pom.xml
+++ b/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-spring-boot</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-spring-boot-starter</artifactId>
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-spring-boot-autoconfigure</artifactId>
-			<version>${revision}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/sqlmapper-sample/pom.xml
+++ b/sqlmapper-sample/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-root</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-sample</artifactId>

--- a/sqlmapper-sample/sqlmapper-sample-spring-boot/pom.xml
+++ b/sqlmapper-sample/sqlmapper-sample-spring-boot/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.mygreen.sqlmapper</groupId>
 		<artifactId>sqlmapper-sample</artifactId>
-		<version>${revision}</version>
+		<version>0.3.1</version>
 	</parent>
 
 	<artifactId>sqlmapper-sample-spring-boot</artifactId>
@@ -192,14 +192,13 @@
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-apt</artifactId>
-			<version>${revision}</version>
-			<scope>provided</scope>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.github.mygreen.sqlmapper</groupId>
 			<artifactId>sqlmapper-spring-boot-starter</artifactId>
-			<version>${revision}</version>
+			<version>${sqlmapper.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
- バージョンを v0.3.1に変更
  - モジュール内のpom.xmlのバージョン指定方式を変数参照形式から、直接指定に変更。
  - Maven Centralからダウンロードする際にバージョンが解決できず、ビルドエラーとなるため。
- ドキュメントの更新
  - リリースノートの更新
