### PR TITLE
テーブルによるID採番の不具合の修正／シーケンス名の決定方法の修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/TableGenerator.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/annotation/TableGenerator.java
@@ -11,6 +11,7 @@ import java.text.DecimalFormat;
  * 識別子(主キー)の値をテーブルにより採番する設定をします。
  * <p>このアノテーションは {@link Id}、{@link GeneratedValue} と併わせて使用しなければいけません。</p>
  *
+ * @version 0.3.2
  * @author T.TSUCHIE
  *
  */
@@ -69,6 +70,14 @@ public @interface TableGenerator {
      * @return 初期値。
      */
     long initialValue() default 0L;
+
+    /**
+     * (オプション) 採番する際の主キーの値としてのシーケンスの名前。
+     *
+     * @since 0.3.2
+     * @return シーケンス名。
+     */
+    String sequenceName() default "";
 
     /**
      * 識別子のクラスタイプが文字列のときに書式を設定することができます。

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/meta/PropertyMetaFactory.java
@@ -338,7 +338,7 @@ public class PropertyMetaFactory {
                         annoSequenceGenerator.get().catalog(),
                         annoSequenceGenerator.get().schema());
             } else {
-                sequenceName = entityMeta.getTableMeta().getName() + "_" + propertyMeta.getColumnMeta().getName();
+                sequenceName = namingRule.sequenceNameForSequenceGenerator(entityMeta.getTableMeta().getName(), propertyMeta.getColumnMeta().getName());
             }
             SequenceIdGenerator sequenceIdGenerator = new SequenceIdGenerator(
                     dialect.getSequenceIncrementer(dataSource, sequenceName), propertyType);
@@ -370,8 +370,6 @@ public class PropertyMetaFactory {
             tableIdContext.setValueColumn(tableIdGeneratorProperties.getValueColumn());
             tableIdContext.setAllocationSize(tableIdGeneratorProperties.getAllocationSize());
             tableIdContext.setInitialValue(tableIdGeneratorProperties.getInitialValue());
-
-            String sequenceName = entityMeta.getTableMeta().getName() + "_" + propertyMeta.getColumnMeta().getName();
 
             annoTableGenerator.ifPresent(a -> {
                 if(!a.table().isEmpty()) {
@@ -423,8 +421,11 @@ public class PropertyMetaFactory {
             });
 
 
-            if(annoTableGenerator.isPresent() && annoTableGenerator.get().pkColumn().isEmpty()) {
-                sequenceName = annoTableGenerator.get().pkColumn();
+            final String sequenceName;
+            if(annoTableGenerator.isPresent() && !annoTableGenerator.get().sequenceName().isEmpty()) {
+                sequenceName = annoTableGenerator.get().sequenceName();
+            } else {
+                sequenceName = namingRule.sequenceNameForTableGenerator(entityMeta.getTableMeta().getName(), propertyMeta.getColumnMeta().getName());
             }
 
             TableIdGenerator tableIdGenerator = new TableIdGenerator(

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/naming/DefaultNamingRule.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/naming/DefaultNamingRule.java
@@ -6,6 +6,7 @@ package com.github.mygreen.sqlmapper.core.naming;
  * <p>エンティティのクラス名、プロパティ名をキャメルケースから、DBのテーブル名、カラム名としてスネークケースに変換する。</p>
  * <p>大文字に変換する。</p>
  *
+ * @version 0.3.2
  * @since 0.3
  * @author T.TSUCHIE
  *
@@ -128,6 +129,24 @@ public class DefaultNamingRule implements NamingRule {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>大文字に変換したテーブル名とカラム名を結合します。({@literal SAMPLE_CUSTOMER}, {@literal sample_name} {@literal =>} {@literal SAMPLE_CUSTOMER_SAMPLE_NAME})
+     */
+    @Override
+    public String sequenceNameForTableGenerator(final String tableName, final String columnName) {
+        return tableName.toUpperCase() + "_" + columnName.toUpperCase();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>大文字に変換したテーブル名とカラム名を結合し、接尾語({@literal SEQ}) を付与します。 ({@literal SAMPLE_CUSTOMER}, {@literal sample_name} {@literal =>} {@literal SAMPLE_CUSTOMER_SAMPLE_NAME})
+     */
+    @Override
+    public String sequenceNameForSequenceGenerator(String tableName, String columnName) {
+        return tableName.toUpperCase() + "_" + columnName.toUpperCase() + "_SEQ";
     }
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/naming/NamingRule.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/naming/NamingRule.java
@@ -4,7 +4,7 @@ package com.github.mygreen.sqlmapper.core.naming;
 /**
  * DBのテーブルやカラムをJavaのエンティティ・クラスにマッピングする際の命名規則に沿った変換を行う。
  *
- *
+ * @version 0.3.2
  * @author T.TSUCHIE
  *
  */
@@ -45,5 +45,26 @@ public interface NamingRule {
      */
     String propertyToStoredParam(String propertyName);
 
+    /**
+     * テーブルによる採番を行う際のシーケンス名を決定します。
+     * <p>テーブル名とカラム名からシーケンス名に変換する。
+     *
+     * @since 0.3.2
+     * @param tableName テーブル名
+     * @param columnName カラム名
+     * @return シーケンス名
+     */
+    String sequenceNameForTableGenerator(String talbeName, String columnName);
+
+    /**
+     * シーケンスによる採番を行う際のシーケンス名を決定します。
+     * <p>テーブル名とカラム名からシーケンス名に変換する。
+     *
+     * @since 0.3.2
+     * @param tableName テーブル名
+     * @param columnName カラム名
+     * @return シーケンス名
+     */
+    String sequenceNameForSequenceGenerator(String tableName, String columnName);
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/naming/DefaultNamingRuleTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/naming/DefaultNamingRuleTest.java
@@ -40,4 +40,15 @@ public class DefaultNamingRuleTest extends DefaultNamingRule {
         assertEquals("id", propertyToStoredParam("id"));
         assertEquals("first_name", propertyToStoredParam("firstName"));
     }
+
+    @Test
+    void testSequenceNameForTableGenerator() {
+        assertEquals("EMPLOYEE_DETAIL_FIRST_NAME", sequenceNameForTableGenerator("Employee_detail", "first_name"));
+    }
+
+    @Test
+    void testSequenceNameForSequenceGenerator() {
+        assertEquals("EMPLOYEE_DETAIL_FIRST_NAME_SEQ", sequenceNameForSequenceGenerator("Employee_detail", "first_name"));
+    }
+
 }

--- a/sqlmapper-parent/sqlmapper-core/src/test/resources/script/h2/create_schema.sql
+++ b/sqlmapper-parent/sqlmapper-core/src/test/resources/script/h2/create_schema.sql
@@ -185,7 +185,7 @@ CREATE TABLE IF NOT EXISTS test_embedded_generated_value (
 	primary key (key1, key2)
 );
 
-CREATE SEQUENCE test_embedded_generated_value_key2 start with 1;
+CREATE SEQUENCE test_embedded_generated_value_key2_seq start with 1;
 
 
 -- 継承したエンティティのテスト

--- a/sqlmapper-parent/sqlmapper-core/src/test/resources/script/h2/reset_data.sql
+++ b/sqlmapper-parent/sqlmapper-core/src/test/resources/script/h2/reset_data.sql
@@ -41,5 +41,5 @@ ALTER TABLE test_embedded_generated_value ALTER COLUMN key1 RESTART WITH 1;
 
 -- シーケンスのリセット : ALTER SEQUENCE <sequence_name> RESTART WITH 1;
 ALTER SEQUENCE test_sequence RESTART WITH 1;
-ALTER SEQUENCE test_embedded_generated_value_key2 RESTART WITH 1;
+ALTER SEQUENCE test_embedded_generated_value_key2_seq RESTART WITH 1;
 


### PR DESCRIPTION
- テーブルによるID採番時に、シーケンス名が空になる事象を修正。
- シーケンス名の決定方法を、`NamingRule` で決定するよう変更。