### PR TITLE
非OracleモードのH2DBのシーケンスインクリメンターの修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-core/pom.xml
+++ b/sqlmapper-parent/sqlmapper-core/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.4.200</version>
+			<version>2.1.210</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/H2Dialect.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/dialect/H2Dialect.java
@@ -3,9 +3,9 @@ package com.github.mygreen.sqlmapper.core.dialect;
 import javax.sql.DataSource;
 
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
-import org.springframework.jdbc.support.incrementer.H2SequenceMaxValueIncrementer;
 
 import com.github.mygreen.sqlmapper.core.annotation.GeneratedValue.GenerationType;
+import com.github.mygreen.sqlmapper.core.id.CustomH2SequenceMaxValueIncrementer;
 
 /**
  * H2用の方言の定義。
@@ -56,11 +56,13 @@ public class H2Dialect extends DialectBase {
     /**
      * {@inheritDoc}
      *
-     * @return {@link H2SequenceMaxValueIncrementer} のインスタンスを返します。
+     * @return {@link CustomH2SequenceMaxValueIncrementer} のインスタンスを返します。
      */
     @Override
     public DataFieldMaxValueIncrementer getSequenceIncrementer(DataSource dataSource, String sequenceName) {
-        return new H2SequenceMaxValueIncrementer(dataSource, sequenceName);
+//        return new H2SequenceMaxValueIncrementer(dataSource, sequenceName);
+        return new CustomH2SequenceMaxValueIncrementer(dataSource, sequenceName);
+
     }
 
 }

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/id/CustomH2SequenceMaxValueIncrementer.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/id/CustomH2SequenceMaxValueIncrementer.java
@@ -1,0 +1,31 @@
+package com.github.mygreen.sqlmapper.core.id;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.support.incrementer.AbstractSequenceMaxValueIncrementer;
+
+/**
+ * H2DB用の非Oracleモード用のシーケンスのインクリメント処理。
+ * <p>v2.xからデフォルトが非Oracleモードとなったため。
+ *
+ * @since 0.3.2
+ * @author T.TSUCHIE
+ *
+ */
+public class CustomH2SequenceMaxValueIncrementer extends AbstractSequenceMaxValueIncrementer {
+
+    /**
+     * コンストラクタ。
+     * @param dataSource データソース
+     * @param sequenceName シーケンス名
+     */
+    public CustomH2SequenceMaxValueIncrementer(DataSource dataSource, String sequenceName) {
+        super(dataSource, sequenceName);
+    }
+
+
+    @Override
+    protected String getSequenceQuery() {
+        return "values next value for " + getIncrementerName();
+    }
+}


### PR DESCRIPTION
- H2DBを `1.4.x` ⇒ `2.1.x` に更新。
- 標準がOracleモードではなくなったので、シーケンスのインクリメンター のSQLが変わったため独自の `CustomH2SequenceMaxValueIncrementer` に変更。
  - 非Oracleモードのシーケンスの採番 : https://stackoverflow.com/questions/61358820/how-to-get-nextvalue-in-a-sequence-using-h2-embedded-database