### PR TITLE
ソースの警告を修正

### DIFF
--- a/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/EntityMetamodelProcessor.java
+++ b/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/EntityMetamodelProcessor.java
@@ -89,7 +89,7 @@ public class EntityMetamodelProcessor extends AbstractProcessor {
         processEntityAnno(roundEnv, entityModeles);
 
         // ソースの生成
-        EntitySpecFactory specFactory = new EntitySpecFactory(messager, metamodelConfig);
+        EntitySpecFactory specFactory = new EntitySpecFactory(metamodelConfig);
         for(EntityMetamodel entityModel : entityModeles) {
             TypeSpec typeSpec = specFactory.create(entityModel);
             generateEntityMetaModel(typeSpec, entityModel);

--- a/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/EntitySpecFactory.java
+++ b/sqlmapper-parent/sqlmapper-apt/src/main/java/com/github/mygreen/sqlmapper/apt/EntitySpecFactory.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.processing.Generated;
-import javax.annotation.processing.Messager;
 import javax.lang.model.element.Modifier;
 
 import com.github.mygreen.sqlmapper.apt.model.AptType;
@@ -51,11 +50,6 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor
 public class EntitySpecFactory {
-
-    /**
-     * APT用のメッセージ出力
-     */
-    private final Messager messager;
 
     /**
      * メタモデルの生成オプション

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/SqlMapper.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/SqlMapper.java
@@ -194,7 +194,7 @@ public class SqlMapper {
      * @param parameter SQLテンプレートのパラメータ
      * @return SQLテンプレートによる抽出を行うクエリ
      */
-    public <T> SqlSelect<T> selectBySqlFile(@NonNull Class<T> baseClass, @NonNull String path, @NonNull SqlTemplateContext parameter) {
+    public <T> SqlSelect<T> selectBySqlFile(@NonNull Class<T> baseClass, @NonNull String path, @NonNull SqlTemplateContext<?> parameter) {
         return new SqlSelectImpl<T>(context, baseClass, context.getSqlTemplateEngine().getTemplate(path), parameter);
     }
 
@@ -214,7 +214,7 @@ public class SqlMapper {
      * @param parameter SQLテンプレートのパラメータ
      * @return カウント結果
      */
-    public long getCountBySqlFile(@NonNull String path, @NonNull SqlTemplateContext parameter) {
+    public long getCountBySqlFile(@NonNull String path, @NonNull SqlTemplateContext<?> parameter) {
         return new SqlCountImpl(context, context.getSqlTemplateEngine().getTemplate(path), parameter)
                 .getCount();
     }
@@ -234,7 +234,7 @@ public class SqlMapper {
      * @param parameter SQLテンプレートのパラメータ
      * @return SQLテンプレートによる更新を行うクエリ
      */
-    public SqlUpdate updateBySqlFile(@NonNull String path, @NonNull SqlTemplateContext parameter) {
+    public SqlUpdate updateBySqlFile(@NonNull String path, @NonNull SqlTemplateContext<?> parameter) {
         return new SqlUpdateImpl(context, context.getSqlTemplateEngine().getTemplate(path), parameter);
     }
 
@@ -257,7 +257,7 @@ public class SqlMapper {
      * @param parameter SQLテンプレートのパラメータ
      * @return SQLテンプレートによる抽出を行うクエリ
      */
-    public <T> SqlSelect<T> selectBySql(@NonNull Class<T> baseClass, @NonNull String sql, @NonNull SqlTemplateContext parameter) {
+    public <T> SqlSelect<T> selectBySql(@NonNull Class<T> baseClass, @NonNull String sql, @NonNull SqlTemplateContext<?> parameter) {
         return new SqlSelectImpl<T>(context, baseClass, context.getSqlTemplateEngine().getTemplateByText(sql), parameter);
     }
 
@@ -277,7 +277,7 @@ public class SqlMapper {
      * @param parameter SQLテンプレートのパラメータ
      * @return カウント結果
      */
-    public long getCountBySql(@NonNull String sql, @NonNull SqlTemplateContext parameter) {
+    public long getCountBySql(@NonNull String sql, @NonNull SqlTemplateContext<?> parameter) {
         return new SqlCountImpl(context, context.getSqlTemplateEngine().getTemplateByText(sql), parameter)
                 .getCount();
     }
@@ -297,7 +297,7 @@ public class SqlMapper {
      * @param parameter SQLテンプレートのパラメータ
      * @return SQLテンプレートによる更新を行うクエリ
      */
-    public SqlUpdate updateBySql(@NonNull String sql, @NonNull SqlTemplateContext parameter) {
+    public SqlUpdate updateBySql(@NonNull String sql, @NonNull SqlTemplateContext<?> parameter) {
         return new SqlUpdateImpl(context, context.getSqlTemplateEngine().getTemplateByText(sql), parameter);
     }
 

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCountImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCountImpl.java
@@ -35,12 +35,12 @@ public class SqlCountImpl implements SqlCount {
      * SQLテンプレートのパラメータです。
      */
     @Getter
-    private final SqlTemplateContext parameter;
+    private final SqlTemplateContext<?> parameter;
 
     @Getter
     private Integer queryTimeout;
 
-    public SqlCountImpl(SqlMapperContext context, SqlTemplate template, SqlTemplateContext parameter) {
+    public SqlCountImpl(SqlMapperContext context, SqlTemplate template, SqlTemplateContext<?> parameter) {
         this.context = context;
         this.template = template;
         this.parameter = parameter;

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectImpl.java
@@ -38,7 +38,7 @@ public class SqlSelectImpl<T> implements SqlSelect<T> {
      * SQLテンプレートのパラメータです。
      */
     @Getter
-    private final SqlTemplateContext parameter;
+    private final SqlTemplateContext<?> parameter;
 
     @Getter
     private final Class<T> baseClass;
@@ -70,7 +70,7 @@ public class SqlSelectImpl<T> implements SqlSelect<T> {
     private int offset = -1;
 
     public SqlSelectImpl(@NonNull SqlMapperContext context, @NonNull Class<T> baseClass,
-            @NonNull SqlTemplate template, @NonNull SqlTemplateContext parameter) {
+            @NonNull SqlTemplate template, @NonNull SqlTemplateContext<?> parameter) {
 
         this.context = context;
         this.template = template;

--- a/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlUpdateImpl.java
+++ b/sqlmapper-parent/sqlmapper-core/src/main/java/com/github/mygreen/sqlmapper/core/query/sql/SqlUpdateImpl.java
@@ -36,12 +36,12 @@ public class SqlUpdateImpl implements SqlUpdate {
      * SQLテンプレートのパラメータです。
      */
     @Getter
-    private final SqlTemplateContext parameter;
+    private final SqlTemplateContext<?> parameter;
 
     @Getter
     private Integer queryTimeout;
 
-    public SqlUpdateImpl(SqlMapperContext context, SqlTemplate template, SqlTemplateContext parameter) {
+    public SqlUpdateImpl(SqlMapperContext context, SqlTemplate template, SqlTemplateContext<?> parameter) {
         this.context = context;
         this.template = template;
         this.parameter = parameter;

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/auto/SamplePgsqlStoredTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/auto/SamplePgsqlStoredTest.java
@@ -220,6 +220,7 @@ public class SamplePgsqlStoredTest {
                 .withProcedureName("test_proc_hello");
 
         Object ret = jdbcCall.execute();
+        System.out.println(ret);
 
     }
 

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCountTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlCountTest.java
@@ -41,7 +41,7 @@ public class SqlCountTest extends QueryTestSupport {
     @Test
     void testBySqlFile() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
 
         long result = sqlMapper.getCountBySqlFile("/sqltemplate/customer_selectByAny.sql", templateContext);
 
@@ -51,7 +51,7 @@ public class SqlCountTest extends QueryTestSupport {
     @Test
     void testBySql() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
 
         String sql = loadResource("/sqltemplate/customer_selectByAny.sql", StandardCharsets.UTF_8);
 

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlEmbeddedEntityTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlEmbeddedEntityTest.java
@@ -42,7 +42,7 @@ public class SqlEmbeddedEntityTest extends QueryTestSupport {
     @Test
     void testSqlSelectByFile() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("id", new EmbeddedTestEntity.PK("001", 2l)));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("id", new EmbeddedTestEntity.PK("001", 2l)));
 
         EmbeddedTestEntity result = sqlMapper.selectBySqlFile(EmbeddedTestEntity.class, "/sqltemplate/embedded_selectById.sql", templateContext)
                 .getSingleResult();
@@ -68,7 +68,7 @@ public class SqlEmbeddedEntityTest extends QueryTestSupport {
     @Test
     void testSqlUpdateBySql_delete() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("id", new EmbeddedTestEntity.PK("001", 2l)));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("id", new EmbeddedTestEntity.PK("001", 2l)));
 
         int count = txNew().execute(action -> sqlMapper.updateBySqlFile("/sqltemplate/embedded_deleteById.sql", templateContext)
                 .execute());

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlInheritanceEntityTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlInheritanceEntityTest.java
@@ -43,7 +43,7 @@ public class SqlInheritanceEntityTest extends QueryTestSupport {
     @Test
     void testSqlSelectByFile() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("createAt", Timestamp.valueOf("2021-01-03 00:00:00")));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("createAt", Timestamp.valueOf("2021-01-03 00:00:00")));
 
         List<InheritanceTestEntity> result = sqlMapper.selectBySqlFile(InheritanceTestEntity.class, "/sqltemplate/inheritance_selectByCreateAt.sql", templateContext)
                 .getResultList();
@@ -59,7 +59,7 @@ public class SqlInheritanceEntityTest extends QueryTestSupport {
     @Test
     void testSqlCountBySql() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("createAt", Timestamp.valueOf("2021-01-03 00:00:00")));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("createAt", Timestamp.valueOf("2021-01-03 00:00:00")));
 
         long result = sqlMapper.getCountBySqlFile("/sqltemplate/inheritance_selectByCreateAt.sql", templateContext);
 
@@ -70,7 +70,7 @@ public class SqlInheritanceEntityTest extends QueryTestSupport {
     @Test
     void testSqlUpdateBySql_delete() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("createAt", Timestamp.valueOf("2021-01-03 00:00:00")));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("createAt", Timestamp.valueOf("2021-01-03 00:00:00")));
 
         int count = txNew().execute(action -> sqlMapper.updateBySqlFile("/sqltemplate/inheritance_deleteByCreateAt.sql", templateContext)
                 .execute());

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlSelectTest.java
@@ -50,7 +50,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
 
         Customer result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectById.sql", templateContext)
                 .getSingleResult();
@@ -66,7 +66,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySql() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
 
         String sql = loadResource("/sqltemplate/customer_selectById.sql", StandardCharsets.UTF_8);
 
@@ -85,7 +85,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile_singleResult_found1() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
 
         Customer result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectById.sql", templateContext)
                 .getSingleResult();
@@ -96,7 +96,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile_singleResult_found0() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("customerId", "xx"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("customerId", "xx"));
 
         assertThatThrownBy(() ->
                 sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectById.sql", templateContext)
@@ -107,7 +107,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile_singleResult_found2() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
 
         assertThatThrownBy(() ->
                 sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectByAny.sql", templateContext)
@@ -118,7 +118,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile_optionalResult_found1() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
 
         Optional<Customer> result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectById.sql", templateContext)
                 .getOptionalResult();
@@ -129,7 +129,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile_optionalResult_found0() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("customerId", "xx"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("customerId", "xx"));
 
         Optional<Customer> result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectById.sql", templateContext)
                 .getOptionalResult();
@@ -141,7 +141,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile_optionalResult_found2() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
 
         assertThatThrownBy(() ->
                 sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectByAny.sql", templateContext)
@@ -152,7 +152,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile_resultList() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
 
         List<Customer> result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectByAny.sql", templateContext)
                     .getResultList();
@@ -166,7 +166,7 @@ public class SqlSelectTest extends QueryTestSupport {
     @Test
     void testBySqlFile_resultStream() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("lastName", "Yamada"));
 
         List<Customer> result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectByAny.sql", templateContext)
                     .getResultStream()
@@ -183,7 +183,7 @@ public class SqlSelectTest extends QueryTestSupport {
 
         Map<String, Object> params = new HashMap<>();
         params.put("lastName", null);
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(params);
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(params);
 
         List<Customer> result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectByAny.sql", templateContext)
                 .limit(5)
@@ -200,7 +200,7 @@ public class SqlSelectTest extends QueryTestSupport {
 
         Map<String, Object> params = new HashMap<>();
         params.put("lastName", null);
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(params);
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(params);
 
         List<Customer> result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectByAny.sql", templateContext)
                 .offset(2)
@@ -217,7 +217,7 @@ public class SqlSelectTest extends QueryTestSupport {
 
         Map<String, Object> params = new HashMap<>();
         params.put("lastName", null);
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(params);
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(params);
 
         List<Customer> result = sqlMapper.selectBySqlFile(Customer.class, "/sqltemplate/customer_selectByAny.sql", templateContext)
                 .offset(2)

--- a/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlUpdateTest.java
+++ b/sqlmapper-parent/sqlmapper-core/src/test/java/com/github/mygreen/sqlmapper/core/query/sql/SqlUpdateTest.java
@@ -45,7 +45,7 @@ public class SqlUpdateTest extends QueryTestSupport {
     @Test
     void testBySqlFile_dete() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
 
         int count = txNew().execute(action ->
                 sqlMapper.updateBySqlFile("/sqltemplate/customer_deleteById.sql", templateContext)
@@ -66,7 +66,7 @@ public class SqlUpdateTest extends QueryTestSupport {
     @Test
     void testBySql_delete() {
 
-        SqlTemplateContext templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
+        SqlTemplateContext<?> templateContext = new MapSqlTemplateContext(Map.of("customerId", "005"));
 
         String sql = loadResource("/sqltemplate/customer_deleteById.sql", StandardCharsets.UTF_8);
 

--- a/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-autoconfigure/src/main/java/com/github/mygreen/sqlmapper/boot/autoconfigure/SqlMapperAutoConfiguration.java
+++ b/sqlmapper-parent/sqlmapper-spring-boot/sqlmapper-spring-boot-autoconfigure/src/main/java/com/github/mygreen/sqlmapper/boot/autoconfigure/SqlMapperAutoConfiguration.java
@@ -2,7 +2,6 @@ package com.github.mygreen.sqlmapper.boot.autoconfigure;
 
 import javax.sql.DataSource;
 
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -12,8 +11,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jdbc.DatabaseDriver;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.annotation.Bean;
@@ -67,12 +64,7 @@ import lombok.extern.slf4j.Slf4j;
 @PropertySource("classpath:/com/github/mygreen/sqlmapper/core/sqlmapper.properties")
 @EnableConfigurationProperties(SqlMapperProperties.class)
 @AutoConfigureAfter(DataSourceAutoConfiguration.class)
-public class SqlMapperAutoConfiguration implements ApplicationContextAware, ApplicationEventPublisherAware {
-
-    /**
-     * Springのアプリケーションコンテキスト
-     */
-    private ApplicationContext applicationContext;
+public class SqlMapperAutoConfiguration implements ApplicationEventPublisherAware {
 
     /**
      * イベントを配信する機能
@@ -87,11 +79,6 @@ public class SqlMapperAutoConfiguration implements ApplicationContextAware, Appl
 
     @Autowired
     private DataSourceProperties dataSourceProperties;
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-       this.applicationContext = applicationContext;
-    }
 
     @Override
     public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {


### PR DESCRIPTION
- splateの `SqlTemplateContext` のGenericsタイプをワイルカード `SqlTemplateContext<?>` に修正し、コンパイラの警告を解消する。
- 未使用の変数やフィールドの定義を削除して警告を解消。。